### PR TITLE
Add issue-first GitHub governance

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/epic.yml
+++ b/.github/ISSUE_TEMPLATE/epic.yml
@@ -1,0 +1,71 @@
+name: Epic
+description: Issue agregadora para objetivos maiores e suas tasks filhas.
+title: "[Epic] "
+labels:
+  - kind:epic
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use epics para agrupar trabalho, nao para receber PRs diretamente.
+        O backlog oficial do repositorio vive em GitHub Issues.
+  - type: textarea
+    id: objective
+    attributes:
+      label: Objetivo
+      description: Resultado de negocio ou tecnico esperado.
+      placeholder: Descreva o objetivo principal do epic.
+    validations:
+      required: true
+  - type: textarea
+    id: definition_of_done
+    attributes:
+      label: Definicao de pronto
+      description: Condicoes objetivas para fechar o epic.
+      placeholder: Liste criterios verificaveis para considerar o epic concluido.
+    validations:
+      required: true
+  - type: textarea
+    id: child_tasks
+    attributes:
+      label: Tasks filhas
+      description: Liste as task issues relacionadas.
+      placeholder: |
+        - [ ] #123
+        - [ ] #124
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area principal
+      description: Aplique o label `area:*` correspondente depois de criar a issue.
+      options:
+        - web
+        - api
+        - core
+        - data
+        - infra
+        - docs
+    validations:
+      required: true
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Prioridade
+      description: Aplique o label `priority:*` correspondente depois de criar a issue.
+      options:
+        - p0
+        - p1
+        - p2
+        - p3
+    validations:
+      required: true
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidencia esperada
+      description: O que precisa existir quando o epic for encerrado.
+      placeholder: Links, docs, releases, ambientes ou validacoes esperadas.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,0 +1,82 @@
+name: Task
+description: Unidade executavel de trabalho vinculada a um epic ou objetivo.
+title: "[Task] "
+labels:
+  - kind:task
+  - status:ready
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Toda alteracao em arquivos versionados deve estar vinculada a uma task.
+        Depois de criar esta issue, aplique tambem labels `priority:*` e `area:*`.
+  - type: input
+    id: parent_epic
+    attributes:
+      label: Epic pai
+      description: Informe o numero da issue epic relacionada, se existir.
+      placeholder: "#5"
+    validations:
+      required: false
+  - type: textarea
+    id: context
+    attributes:
+      label: Contexto
+      description: Problema atual e motivacao da task.
+      placeholder: Explique o contexto que torna esta task necessaria.
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Criterios de aceite
+      description: O que precisa ser verdade para considerar a task concluida.
+      placeholder: Liste criterios verificaveis.
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area principal
+      description: Aplique o label `area:*` correspondente depois de criar a issue.
+      options:
+        - web
+        - api
+        - core
+        - data
+        - infra
+        - docs
+    validations:
+      required: true
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Prioridade
+      description: Aplique o label `priority:*` correspondente depois de criar a issue.
+      options:
+        - p0
+        - p1
+        - p2
+        - p3
+    validations:
+      required: true
+  - type: textarea
+    id: execution_checklist
+    attributes:
+      label: Checklist de execucao
+      description: Edite esta lista no corpo da issue conforme o trabalho avancar.
+      value: |
+        - [ ] Escopo confirmado
+        - [ ] Implementacao concluida
+        - [ ] Validacao executada
+        - [ ] Issue/docs atualizados
+    validations:
+      required: true
+  - type: textarea
+    id: validation
+    attributes:
+      label: Validacao esperada
+      description: Comandos, checagens ou evidencias que devem ser executados.
+      placeholder: Tests, builds, checks, screenshots, links ou outros artefatos.
+    validations:
+      required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+## Issue
+
+Closes #
+
+## Resumo
+
+- descreva o escopo principal desta PR
+
+## Validacao
+
+- [ ] validacoes executadas e registradas abaixo
+
+```text
+# comandos executados
+```
+
+## Checklist
+
+- [ ] a branch segue `codex/<issue-number>-<slug>`
+- [ ] a issue vinculada esta atualizada com checklist/status/evidencias
+- [ ] docs relevantes foram atualizados quando necessario

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,3 +19,5 @@ Closes #
 - [ ] a branch segue `codex/<issue-number>-<slug>`
 - [ ] a issue vinculada esta atualizada com checklist/status/evidencias
 - [ ] docs relevantes foram atualizados quando necessario
+- [ ] PR em draft apenas enquanto o trabalho ou as validacoes ainda estiverem incompletos
+- [ ] pronto para `squash merge` em `master` quando os checks estiverem verdes

--- a/.github/workflows/pr-issue-guardrails.yml
+++ b/.github/workflows/pr-issue-guardrails.yml
@@ -1,0 +1,70 @@
+name: PR Issue Guardrails
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+
+jobs:
+  validate-pr-issue-contract:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate branch and issue linkage
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const branch = context.payload.pull_request.head.ref;
+            const branchMatch = branch.match(/^codex\/(\d+)-[a-z0-9][a-z0-9-]*$/);
+
+            if (!branchMatch) {
+              core.setFailed(
+                `Branch invalida: "${branch}". Use codex/<issue-number>-<slug>.`,
+              );
+              return;
+            }
+
+            const issueNumber = Number(branchMatch[1]);
+            const body = context.payload.pull_request.body || "";
+            const closesPattern = new RegExp(`\\bCloses\\s+#${issueNumber}\\b`, "i");
+
+            if (!closesPattern.test(body)) {
+              core.setFailed(
+                `A PR deve conter "Closes #${issueNumber}" no corpo para fechar a task correta.`,
+              );
+              return;
+            }
+
+            const { data: issue } = await github.rest.issues.get({
+              ...context.repo,
+              issue_number: issueNumber,
+            });
+
+            if (issue.pull_request) {
+              core.setFailed(
+                `#${issueNumber} referencia uma pull request. Vincule a PR a uma task issue, nao a outra PR.`,
+              );
+              return;
+            }
+
+            if (issue.state !== "open") {
+              core.setFailed(`A issue #${issueNumber} precisa estar aberta enquanto a PR estiver em revisao.`);
+              return;
+            }
+
+            const labels = issue.labels.map((label) =>
+              typeof label === "string" ? label : label.name,
+            );
+
+            if (!labels.includes("kind:task")) {
+              core.setFailed(
+                `A issue #${issueNumber} precisa ter o label "kind:task". Epics nao devem ser fechados por PR.`,
+              );
+            }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,27 @@ repositorio.
 7. Antes de encerrar, atualize checklist, evidencias e docs afetados.
 8. A task fecha com o merge da PR. Epics fecham manualmente.
 
+## Regra de commit, push e merge
+
+- Nao deixe trabalho concluido apenas localmente.
+- Faca `commit` quando houver um checkpoint coerente e verificavel:
+  - uma parte funcional completa;
+  - uma correção validada;
+  - ou antes de uma mudanca mais arriscada que mereca rollback claro.
+- Faca `push` quando:
+  - existir um commit verificavel que nao deve ficar so local;
+  - a task precisar de backup remoto, handoff ou atualizacao da PR;
+  - o fim da sessao deixar trabalho relevante em andamento.
+- Abra ou atualize a PR assim que a branch estiver revisavel, mesmo em draft.
+- Quando a task estiver completa e as validacoes relevantes tiverem passado:
+  - atualize a issue;
+  - marque a PR como pronta;
+  - faca merge para `master` se nao houver bloqueio explicito do usuario.
+- Preferencia de merge: `squash merge`.
+- Depois do merge:
+  - confirme o fechamento da task;
+  - confirme que a branch remota sera removida automaticamente.
+
 ## Regras para issues
 
 - `Epics` agregam contexto, objetivos e links para tasks filhas.
@@ -48,3 +69,4 @@ repositorio.
 - Execute as validacoes relevantes.
 - Atualize a issue com a evidencia principal.
 - Confirme que a PR referencia a mesma issue da branch.
+- Se a branch estiver pronta, nao pare em "codigo feito": publique e finalize o merge.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,50 @@
+# AGENTS.md
+
+Contrato operacional para qualquer agente ou pessoa que trabalhe neste
+repositorio.
+
+## Fonte de verdade
+
+- O backlog oficial vive em `GitHub Issues`.
+- `docs/AGENTS.md` registra estado atual e historico de sessoes. Nao use esse
+  arquivo como lista viva de tarefas.
+- `docs/STUDENT_PACK_PLAN.md` resume o roadmap e aponta para issues/milestones.
+  Nao replique nele o backlog operacional dia a dia.
+
+## Fluxo obrigatorio
+
+1. Localize uma `task issue` aberta antes de alterar qualquer arquivo versionado.
+2. Se a task ainda nao existir, crie uma issue a partir do template correto.
+3. Garanta que a issue tenha, no minimo:
+   - `kind:task`
+   - um label `status:*`
+   - um label `priority:*`
+   - um label `area:*`
+4. Ao iniciar, marque a task como `status:in-progress` e atualize o checklist do
+   corpo da issue.
+5. Trabalhe em branch no formato `codex/<issue-number>-<slug>`.
+6. Abra PR com `Closes #<issue-number>` no corpo.
+7. Antes de encerrar, atualize checklist, evidencias e docs afetados.
+8. A task fecha com o merge da PR. Epics fecham manualmente.
+
+## Regras para issues
+
+- `Epics` agregam contexto, objetivos e links para tasks filhas.
+- `Tasks` sao a unidade executavel de trabalho.
+- Se uma task crescer demais, abra uma follow-up issue e reduza o escopo da
+  issue atual.
+- Se um issue estiver defasado, atualize o corpo para refletir apenas o trabalho
+  restante ou feche como `superseded`, apontando para o substituto.
+
+## Onde registrar o que
+
+- Estado tecnico atual e sessoes: `docs/AGENTS.md`
+- Decisoes duraveis: `docs/decisions/`
+- Roadmap de Student Pack e backlog resumido: `docs/STUDENT_PACK_PLAN.md`
+- Release notes: `docs/releases/`
+
+## Antes de marcar como concluido
+
+- Execute as validacoes relevantes.
+- Atualize a issue com a evidencia principal.
+- Confirme que a PR referencia a mesma issue da branch.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,20 @@ Before changing any versioned file:
 4. Work in a branch named `codex/<issue-number>-<slug>`.
 5. Open a PR with `Closes #<issue-number>` in the body.
 6. Update the issue and relevant docs before considering the task complete.
+7. Commit validated checkpoints, push them promptly, and merge to `master` when the task is complete and checks are green unless the user explicitly says not to.
+
+## Publish and Merge Policy
+
+- Do not leave completed work only in the local worktree.
+- Commit when you reach a coherent, validated checkpoint.
+- Push when the checkpoint should be preserved remotely or reflected in the PR.
+- Open or update a draft PR as soon as the branch is reviewable.
+- When acceptance criteria are satisfied and relevant checks pass:
+  - update the issue;
+  - mark the PR ready if needed;
+  - merge into `master`.
+- Prefer squash merge for short-lived Codex branches.
+- After merge, confirm the linked task closes and the remote branch is removed when possible.
 
 Do not use `docs/AGENTS.md` as a backlog. The official backlog lives in GitHub Issues.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,21 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 Hybrid Python project: a CLI scraper that extracts DFP/ITR financial reports from Brazil's CVM regulator and persists them to SQLite/PostgreSQL, plus a Streamlit analytics dashboard and a PyQt6 desktop app for 449+ public companies.
 
 > For business rules, pipeline details, and troubleshooting see `docs/CONTEXT.md`.
+> For the issue-first workflow required in this repo see `AGENTS.md`.
 > For current state and session history see `docs/AGENTS.md`.
+
+## Required Workflow
+
+Before changing any versioned file:
+
+1. Find or create an open `task issue` in GitHub.
+2. Ensure the issue has `kind:task`, one `status:*`, one `priority:*`, and one `area:*` label.
+3. Update the issue when work starts and keep the checklist/evidence current.
+4. Work in a branch named `codex/<issue-number>-<slug>`.
+5. Open a PR with `Closes #<issue-number>` in the body.
+6. Update the issue and relevant docs before considering the task complete.
+
+Do not use `docs/AGENTS.md` as a backlog. The official backlog lives in GitHub Issues.
 
 ## Commands
 
@@ -177,10 +191,10 @@ Dead/archived scripts are in `archive/` at the repo root — do not touch those.
 - One task per subagent for focused execution
 
 ### 3. Self-Improvement Loop
-- After ANY correction from the user: update `tasks/lessons.md` with the pattern
+- After ANY correction from the user: record the lesson in the relevant issue comment, ADR, or durable doc
 - Write rules for yourself that prevent the same mistake
 - Ruthlessly iterate on these lessons until mistake rate drops
-- Review lessons at session start for relevant project
+- Review recent issues and docs before repeating work
 
 ### 4. Verification Before Done
 - Never mark a task complete without proving it works
@@ -200,14 +214,13 @@ Dead/archived scripts are in `archive/` at the repo root — do not touch those.
 - Zero context switching required from the user
 - Go fix failing CI tests without being told how
 
-## Task Management
+## Issue Management
 
-1. **Plan First**: Write plan to `tasks/todo.md` with checkable items
-2. **Verify Plan**: Check in before starting implementation
-3. **Track Progress**: Mark items complete as you go
-4. **Explain Changes**: High-level summary at each step
-5. **Document Results**: Add review section to `tasks/todo.md`
-6. **Capture Lessons**: Update `tasks/lessons.md` after corrections
+1. **Issue First**: no executable work starts without a `task issue`
+2. **Branch From Issue**: use `codex/<issue-number>-<slug>`
+3. **Track Progress in Issue**: keep status, checklist, and evidence current
+4. **Close via PR**: use `Closes #<issue-number>` in the PR body
+5. **Keep Docs Durable**: ADRs and durable docs stay in `docs/`; operational state stays in GitHub Issues
 
 ## Core Principles
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,19 @@
+# Contributing
+
+## Issue-first workflow
+
+- Todo trabalho executavel deve nascer ou estar vinculado a uma `task issue`.
+- Use branch no formato `codex/<issue-number>-<slug>`.
+- Abra PR com `Closes #<issue-number>`.
+- Atualize checklist, status e evidencias na issue antes do merge.
+
+## Tipos de issue
+
+- `Epic`: agrega contexto, objetivo e tasks filhas.
+- `Task`: unidade executavel de trabalho.
+
+## Fonte de verdade
+
+- Backlog oficial: GitHub Issues
+- Estado tecnico e historico: `docs/AGENTS.md`
+- Regras para agentes: `AGENTS.md`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,8 @@
 - Use branch no formato `codex/<issue-number>-<slug>`.
 - Abra PR com `Closes #<issue-number>`.
 - Atualize checklist, status e evidencias na issue antes do merge.
+- Faca `commit` em checkpoints verificaveis, `push` ao finalizar um checkpoint remoto e `merge` para `master` quando a task estiver concluida e os checks estiverem verdes.
+- Preferencia de merge: `squash merge`.
 
 ## Tipos de issue
 

--- a/apps/web/app/design-system/layout.tsx
+++ b/apps/web/app/design-system/layout.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
@@ -6,8 +7,12 @@ export const metadata: Metadata = {
     "Catalogo interno de tokens, componentes e recipes visuais que orientam a UI do CVM Analytics.",
 };
 
+type DesignSystemLayoutProps = {
+  children: ReactNode;
+};
+
 export default function DesignSystemLayout({
   children,
-}: LayoutProps<"/design-system">) {
+}: DesignSystemLayoutProps) {
   return <>{children}</>;
 }

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react";
 import type { Metadata } from "next";
 import { IBM_Plex_Mono, Manrope, Space_Grotesk } from "next/font/google";
 
@@ -31,7 +32,11 @@ export const metadata: Metadata = {
     "Plataforma publica de analise financeira com dados da CVM para descoberta rapida, leitura historica e navegacao por empresas.",
 };
 
-export default function RootLayout({ children }: LayoutProps<"/">) {
+type RootLayoutProps = {
+  children: ReactNode;
+};
+
+export default function RootLayout({ children }: RootLayoutProps) {
   return (
     <html
       lang="pt-BR"

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,8 +1,9 @@
 # AGENTS.md - Estado Atual e Historico de Sessoes
 
 > **Para agentes de IA.** Estado atual no topo; historico abaixo.
-> Antes de modificar o codigo, leia este arquivo e `docs/CONTEXT.md`.
+> Antes de modificar o codigo, leia `AGENTS.md`, este arquivo e `docs/CONTEXT.md`.
 > Apos concluir, atualize a secao "Estado Atual" e adicione uma entrada de sessao quando fizer sentido.
+> Backlog oficial: `GitHub Issues`. Este arquivo nao e uma lista viva de tarefas.
 
 ---
 
@@ -47,7 +48,13 @@
 - `pytest apps/api/tests -q` cobre o contrato HTTP da Fase 1 da V2
 - `apps/web` valida com `npm run lint`, `npm run typecheck`, `npm run build` e `npm run test:e2e`
 
-### Issues Abertas
+### Governanca de Trabalho
+- `GitHub Issues` passa a ser a fonte oficial do backlog e do status do trabalho
+- `AGENTS.md` na raiz define o contrato operacional `issue -> branch -> PR -> merge`
+- `docs/STUDENT_PACK_PLAN.md` deixa de espelhar task-by-task e passa a apontar para milestone + epics + filtros de issues
+- `docs/AGENTS.md` permanece apenas como estado atual e historico de sessoes
+
+### Pendencias Tecnicas Atuais
 - Validacao contra PostgreSQL real ainda depende de `DATABASE_URL` valido
 - Deploy de preview da V2 ainda nao foi iniciado
 - Streamlit Cloud deploy pendente
@@ -71,6 +78,16 @@
 ---
 
 ## Sessoes Recentes
+
+### Sessao 31 - 2026-04-08 (governanca issue-first no GitHub)
+- `AGENTS.md` criado na raiz como contrato operacional para agentes e contribuidores
+- `.github/ISSUE_TEMPLATE/` criado com forms de `epic` e `task`; blank issues desabilitadas
+- `.github/PULL_REQUEST_TEMPLATE.md` criado com referencia obrigatoria a issue
+- `.github/workflows/pr-issue-guardrails.yml` criado para validar branch `codex/<issue-number>-<slug>`, `Closes #<issue>` e label `kind:task`
+- `CLAUDE.md` atualizado para abandonar `tasks/todo.md` e seguir fluxo issue-first
+- `docs/STUDENT_PACK_PLAN.md` atualizado para apontar para milestone/epics/tasks do GitHub em vez de espelhar backlog diario
+- Labels operacionais criadas no GitHub: `kind:*`, `status:*`, `priority:*`, `area:*`
+- Triage inicial aplicada aos issues `#2` a `#14`, com `#12` fechado como concluido por evidencia ja entregue
 
 ### Sessao 30 - 2026-04-08 (design system + biblioteca de componentes V2 web)
 - `/design-system` criada como showcase de tokens e componentes (24 secoes, sidebar nav)

--- a/docs/STUDENT_PACK_PLAN.md
+++ b/docs/STUDENT_PACK_PLAN.md
@@ -148,26 +148,20 @@ Decisao esperada ao final de 2026-06-04:
 
 ## 7. Backlog no GitHub
 
-Milestone alvo: `Student Pack 60 dias` com data alvo em 2026-06-04.
+O backlog operacional oficial agora vive em `GitHub Issues`.
 
-Milestone criado:
-- [Student Pack 60 dias](https://github.com/jadaojoao/cvm_repots_capture/milestone/1)
+Use sempre:
+- milestone atual: [Student Pack 60 dias](https://github.com/jadaojoao/cvm_repots_capture/milestone/1)
+- epics abertas: [filtro de epics](https://github.com/jadaojoao/cvm_repots_capture/issues?q=is%3Aissue+is%3Aopen+milestone%3A%22Student+Pack+60+dias%22+label%3Akind%3Aepic)
+- tasks abertas: [filtro de tasks](https://github.com/jadaojoao/cvm_repots_capture/issues?q=is%3Aissue+is%3Aopen+milestone%3A%22Student+Pack+60+dias%22+label%3Akind%3Atask)
 
-Epicos criados:
+Epics atuais:
 1. [#2 - Student Pack Activation](https://github.com/jadaojoao/cvm_repots_capture/issues/2)
 2. [#3 - Current Stack Stabilization](https://github.com/jadaojoao/cvm_repots_capture/issues/3)
 3. [#4 - Observability and Quality](https://github.com/jadaojoao/cvm_repots_capture/issues/4)
 4. [#5 - V2 Discovery](https://github.com/jadaojoao/cvm_repots_capture/issues/5)
 
-Tasks criadas:
-- [#6 - Registrar e ativar beneficios priorizados do Student Pack](https://github.com/jadaojoao/cvm_repots_capture/issues/6)
-- [#7 - Concluir trilha inicial de Frontend Masters e registrar aprendizados](https://github.com/jadaojoao/cvm_repots_capture/issues/7)
-- [#8 - Integrar Codecov ao CI atual](https://github.com/jadaojoao/cvm_repots_capture/issues/8)
-- [#9 - Escolher ambiente cloud de aprendizado para a V2](https://github.com/jadaojoao/cvm_repots_capture/issues/9)
-- [#10 - Validar fluxo local completo e documentar fronteira da V1](https://github.com/jadaojoao/cvm_repots_capture/issues/10)
-- [#11 - Escrever ADR de criterios de escolha da V2](https://github.com/jadaojoao/cvm_repots_capture/issues/11)
-- [#12 - Definir stack da V2 e contrato inicial da API](https://github.com/jadaojoao/cvm_repots_capture/issues/12)
-- [#13 - Integrar Sentry no primeiro runtime remoto](https://github.com/jadaojoao/cvm_repots_capture/issues/13)
-- [#14 - Entregar primeira fatia da V2 em ambiente de teste](https://github.com/jadaojoao/cvm_repots_capture/issues/14)
-
-Este documento deve ser sincronizado com as issues do GitHub sempre que uma tarefa for criada, reordenada, ativada ou concluida.
+Regras de operacao:
+- toda mudanca em arquivo versionado deve estar vinculada a uma `task issue`
+- backlog diario, status e concluido vivem nas issues, nao neste documento
+- este arquivo resume direcao e links, mas nao espelha a lista viva de tasks


### PR DESCRIPTION
## Issue

Closes #17

## Resumo

- adiciona contrato operacional `issue -> branch -> PR -> merge` ao repositorio
- cria issue forms de `epic` e `task`, PR template e workflow de guardrail para PRs
- atualiza `CLAUDE.md`, `docs/AGENTS.md` e `docs/STUDENT_PACK_PLAN.md` para o fluxo issue-first
- publica labels operacionais e triagem inicial dos issues `#2` a `#14`

## Validacao

- [x] parse YAML dos novos arquivos em `.github/ISSUE_TEMPLATE/` e `.github/workflows/pr-issue-guardrails.yml`
- [x] `git diff --check`
- [x] labels operacionais criadas e issues abertas reclassificadas no GitHub

```text
python - <<'PY'
from pathlib import Path
import yaml
for path in [
    Path('.github/ISSUE_TEMPLATE/config.yml'),
    Path('.github/ISSUE_TEMPLATE/epic.yml'),
    Path('.github/ISSUE_TEMPLATE/task.yml'),
    Path('.github/workflows/pr-issue-guardrails.yml'),
]:
    with path.open('r', encoding='utf-8') as fh:
        yaml.safe_load(fh)
print('yaml ok')
PY

git diff --check
```

## Checklist

- [x] a branch segue `codex/<issue-number>-<slug>`
- [x] a issue vinculada esta atualizada com checklist/status/evidencias
- [x] docs relevantes foram atualizados quando necessario
