### PR TITLE
Rename universal branch prefix to task

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,7 +16,7 @@ Closes #
 
 ## Checklist
 
-- [ ] a branch segue `codex/<issue-number>-<slug>`
+- [ ] a branch segue `task/<issue-number>-<slug>`
 - [ ] a issue vinculada esta atualizada com checklist/status/evidencias
 - [ ] docs relevantes foram atualizados quando necessario
 - [ ] PR em draft apenas enquanto o trabalho ou as validacoes ainda estiverem incompletos

--- a/.github/workflows/pr-issue-guardrails.yml
+++ b/.github/workflows/pr-issue-guardrails.yml
@@ -22,11 +22,11 @@ jobs:
         with:
           script: |
             const branch = context.payload.pull_request.head.ref;
-            const branchMatch = branch.match(/^codex\/(\d+)-[a-z0-9][a-z0-9-]*$/);
+            const branchMatch = branch.match(/^task\/(\d+)-[a-z0-9][a-z0-9-]*$/);
 
             if (!branchMatch) {
               core.setFailed(
-                `Branch invalida: "${branch}". Use codex/<issue-number>-<slug>.`,
+                `Branch invalida: "${branch}". Use task/<issue-number>-<slug>.`,
               );
               return;
             }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ repositorio.
    - um label `area:*`
 4. Ao iniciar, marque a task como `status:in-progress` e atualize o checklist do
    corpo da issue.
-5. Trabalhe em branch no formato `codex/<issue-number>-<slug>`.
+5. Trabalhe em branch no formato `task/<issue-number>-<slug>`.
 6. Abra PR com `Closes #<issue-number>` no corpo.
 7. Antes de encerrar, atualize checklist, evidencias e docs afetados.
 8. A task fecha com o merge da PR. Epics fecham manualmente.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ Before changing any versioned file:
 1. Find or create an open `task issue` in GitHub.
 2. Ensure the issue has `kind:task`, one `status:*`, one `priority:*`, and one `area:*` label.
 3. Update the issue when work starts and keep the checklist/evidence current.
-4. Work in a branch named `codex/<issue-number>-<slug>`.
+4. Work in a branch named `task/<issue-number>-<slug>`.
 5. Open a PR with `Closes #<issue-number>` in the body.
 6. Update the issue and relevant docs before considering the task complete.
 7. Commit validated checkpoints, push them promptly, and merge to `master` when the task is complete and checks are green unless the user explicitly says not to.
@@ -231,7 +231,7 @@ Dead/archived scripts are in `archive/` at the repo root — do not touch those.
 ## Issue Management
 
 1. **Issue First**: no executable work starts without a `task issue`
-2. **Branch From Issue**: use `codex/<issue-number>-<slug>`
+2. **Branch From Issue**: use `task/<issue-number>-<slug>`
 3. **Track Progress in Issue**: keep status, checklist, and evidence current
 4. **Close via PR**: use `Closes #<issue-number>` in the PR body
 5. **Keep Docs Durable**: ADRs and durable docs stay in `docs/`; operational state stays in GitHub Issues

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 ## Issue-first workflow
 
 - Todo trabalho executavel deve nascer ou estar vinculado a uma `task issue`.
-- Use branch no formato `codex/<issue-number>-<slug>`.
+- Use branch no formato `task/<issue-number>-<slug>`.
 - Abra PR com `Closes #<issue-number>`.
 - Atualize checklist, status e evidencias na issue antes do merge.
 - Faca `commit` em checkpoints verificaveis, `push` ao finalizar um checkpoint remoto e `merge` para `master` quando a task estiver concluida e os checks estiverem verdes.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -83,7 +83,7 @@
 - `AGENTS.md` criado na raiz como contrato operacional para agentes e contribuidores
 - `.github/ISSUE_TEMPLATE/` criado com forms de `epic` e `task`; blank issues desabilitadas
 - `.github/PULL_REQUEST_TEMPLATE.md` criado com referencia obrigatoria a issue
-- `.github/workflows/pr-issue-guardrails.yml` criado para validar branch `codex/<issue-number>-<slug>`, `Closes #<issue>` e label `kind:task`
+- `.github/workflows/pr-issue-guardrails.yml` criado para validar branch `task/<issue-number>-<slug>`, `Closes #<issue>` e label `kind:task`
 - `CLAUDE.md` atualizado para abandonar `tasks/todo.md` e seguir fluxo issue-first
 - `docs/STUDENT_PACK_PLAN.md` atualizado para apontar para milestone/epics/tasks do GitHub em vez de espelhar backlog diario
 - Labels operacionais criadas no GitHub: `kind:*`, `status:*`, `priority:*`, `area:*`


### PR DESCRIPTION
## Issue

Closes #19

## Resumo

- troca o prefixo universal de branch de `codex/` para `task/`
- atualiza contratos de agentes, contribuicao e template de PR
- ajusta o guardrail de PR para validar `task/<issue-number>-<slug>`

## Validacao

- [x] `git diff --check`
- [x] parse YAML de `.github/workflows/pr-issue-guardrails.yml`

```text
git diff --check
python - <<'PY'
from pathlib import Path
import yaml
with Path('.github/workflows/pr-issue-guardrails.yml').open('r', encoding='utf-8') as fh:
    yaml.safe_load(fh)
print('yaml ok')
PY
```

## Checklist

- [x] a branch segue `task/<issue-number>-<slug>`
- [x] a issue vinculada esta atualizada com checklist/status/evidencias
- [x] docs relevantes foram atualizados quando necessario
- [x] PR em draft apenas enquanto o trabalho ou as validacoes ainda estiverem incompletos
- [x] pronto para `squash merge` em `master` quando os checks estiverem verdes
