### PR TITLE
feat(web): implementar pacote PG-04 comparar

### DIFF
--- a/apps/web/app/comparar/page.tsx
+++ b/apps/web/app/comparar/page.tsx
@@ -1,0 +1,156 @@
+import Link from "next/link";
+import type { Metadata } from "next";
+
+import { CompareKpiTable } from "@/components/compare/compare-kpi-table";
+import { CompareSelector } from "@/components/compare/compare-selector";
+import { CompareTracker } from "@/components/compare/compare-tracker";
+import {
+  InfoChip,
+  PageShell,
+  SectionHeading,
+  SurfaceCard,
+} from "@/components/shared/design-system-recipes";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { buttonVariants } from "@/components/ui/button";
+import { fetchCompanies } from "@/lib/api";
+import {
+  loadComparePageData,
+  type CompareCompanyOption,
+} from "@/lib/compare-page-data";
+import { getFirstParam } from "@/lib/search-params";
+import { cn } from "@/lib/utils";
+
+export const metadata: Metadata = {
+  title: "Comparar",
+  description:
+    "Comparacao lado a lado de empresas com base nos KPIs anuais da API V2.",
+};
+
+export const dynamic = "force-dynamic";
+
+type ComparePageProps = {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+};
+
+function toQuickOption(item: {
+  cd_cvm: number;
+  company_name: string;
+  ticker_b3: string | null;
+  sector_name: string;
+}): CompareCompanyOption {
+  return {
+    cd_cvm: item.cd_cvm,
+    company_name: item.company_name,
+    ticker_b3: item.ticker_b3,
+    sector_name: item.sector_name,
+  };
+}
+
+export default async function ComparePage({ searchParams }: ComparePageProps) {
+  const resolvedSearchParams = await searchParams;
+  const ids = getFirstParam(resolvedSearchParams.ids);
+  const years = getFirstParam(resolvedSearchParams.anos);
+
+  const [compareData, quickPayload] = await Promise.all([
+    loadComparePageData(ids, years),
+    fetchCompanies({ page: 1, pageSize: 8 }).catch(() => null),
+  ]);
+
+  const quickCompanies = (quickPayload?.items ?? []).map(toQuickOption);
+  const saneQuickCompanies = quickCompanies.filter(
+    (company) =>
+      Number.isFinite(company.cd_cvm) &&
+      company.cd_cvm > 0 &&
+      company.company_name.trim() !== "--",
+  );
+
+  return (
+    <PageShell density="default">
+      <CompareTracker
+        companyIds={compareData.selectedCompanies.map((company) => company.cd_cvm)}
+        years={compareData.selectedYears}
+        comparableCompanies={compareData.comparedCompanies.length}
+      />
+
+      <SectionHeading
+        eyebrow="PG-04 - Comparar"
+        title="Comparacao de empresas"
+        titleAs="h1"
+        description="Monte uma comparacao lado a lado com empresas da base e use a primeira selecao como referencia de deltas."
+        meta={
+          <InfoChip tone="muted">
+            {compareData.comparedCompanies.length >= 2
+              ? `${compareData.comparedCompanies.length} empresas comparaveis`
+              : "Selecione ao menos 2 empresas"}
+          </InfoChip>
+        }
+      />
+
+      <CompareSelector
+        pathname="/comparar"
+        selectedCompanies={compareData.selectedCompanies}
+        quickCompanies={saneQuickCompanies}
+        availableYears={compareData.availableYears}
+        selectedYears={compareData.selectedYears}
+      />
+
+      {compareData.dataError ? (
+        <Alert className="rounded-[1.75rem] border border-destructive/25 bg-destructive/6 px-5 py-5 text-left">
+          <AlertTitle>Comparacao indisponivel no estado atual</AlertTitle>
+          <AlertDescription>{compareData.dataError}</AlertDescription>
+        </Alert>
+      ) : null}
+
+      {compareData.partialErrors.length > 0 ? (
+        <Alert className="rounded-[1.75rem] border border-border/70 bg-background/85 px-5 py-4 text-left">
+          <AlertTitle>Alguns dados nao puderam ser carregados</AlertTitle>
+          <AlertDescription>
+            {compareData.partialErrors.slice(0, 3).join(" ")}
+          </AlertDescription>
+        </Alert>
+      ) : null}
+
+      {compareData.selectedCompanies.length < 2 ? (
+        <SurfaceCard tone="muted" padding="hero" className="space-y-5">
+          <SectionHeading
+            eyebrow="Passo inicial"
+            title="Selecione ao menos duas empresas"
+            titleAs="h2"
+            description="Use a busca da comparacao ou entre pelo diretorio de empresas para montar a primeira analise lado a lado."
+            descriptionClassName="text-sm leading-7"
+          />
+          <div className="flex flex-wrap gap-3">
+            <Link
+              href="/empresas"
+              className={cn(
+                buttonVariants({ size: "lg" }),
+                "rounded-full px-5",
+              )}
+            >
+              Abrir diretorio
+            </Link>
+            <Link
+              href="/"
+              className={cn(
+                buttonVariants({ variant: "outline", size: "lg" }),
+                "rounded-full px-5",
+              )}
+            >
+              Voltar para home
+            </Link>
+          </div>
+        </SurfaceCard>
+      ) : null}
+
+      {compareData.comparedCompanies.length >= 2 &&
+      compareData.referenceYear !== null &&
+      compareData.rows.length > 0 ? (
+        <CompareKpiTable
+          companies={compareData.comparedCompanies}
+          rows={compareData.rows}
+          referenceYear={compareData.referenceYear}
+        />
+      ) : null}
+    </PageShell>
+  );
+}

--- a/apps/web/app/not-found.tsx
+++ b/apps/web/app/not-found.tsx
@@ -21,7 +21,7 @@ export default function NotFound() {
         <SectionHeading
           title="Esse caminho ainda nao existe nesta fase."
           titleAs="h1"
-          description="O slice atual cobre a home, o diretorio de empresas e o detalhe por companhia. Rotas de comparacao, setores, KPIs e macro entram nas proximas fases."
+          description="O slice atual cobre a home, o diretorio de empresas, a comparacao e o detalhe por companhia. Rotas de setores, KPIs e macro entram nas proximas fases."
           bodyClassName="mx-auto max-w-2xl"
           descriptionClassName="mx-auto"
         />

--- a/apps/web/components/company/company-header.tsx
+++ b/apps/web/components/company/company-header.tsx
@@ -5,8 +5,9 @@ import {
   InfoChip,
   SurfaceCard,
 } from "@/components/shared/design-system-recipes";
-import { Button } from "@/components/ui/button";
+import { Button, buttonVariants } from "@/components/ui/button";
 import type { CompanyInfo } from "@/lib/api";
+import { cn } from "@/lib/utils";
 
 type CompanyHeaderProps = {
   company: CompanyInfo;
@@ -17,6 +18,14 @@ export function CompanyHeader({
   company,
   selectedYears,
 }: CompanyHeaderProps) {
+  const compareParams = new URLSearchParams({
+    ids: String(company.cd_cvm),
+  });
+  if (selectedYears.length > 0) {
+    compareParams.set("anos", selectedYears.join(","));
+  }
+  const compareHref = `/comparar?${compareParams.toString()}`;
+
   return (
     <div className="space-y-5">
       <nav aria-label="breadcrumb">
@@ -68,14 +77,15 @@ export function CompanyHeader({
             >
               Ver setor em breve
             </Button>
-            <Button
-              variant="outline"
-              size="lg"
-              className="rounded-full px-5"
-              disabled
+            <Link
+              href={compareHref}
+              className={cn(
+                buttonVariants({ variant: "outline", size: "lg" }),
+                "rounded-full px-5",
+              )}
             >
-              Comparar em breve
-            </Button>
+              Comparar empresa
+            </Link>
           </div>
         </div>
       </SurfaceCard>

--- a/apps/web/components/compare/compare-kpi-table.tsx
+++ b/apps/web/components/compare/compare-kpi-table.tsx
@@ -1,0 +1,111 @@
+import Link from "next/link";
+
+import {
+  SectionHeading,
+  SurfaceCard,
+} from "@/components/shared/design-system-recipes";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import type { CompareKpiRow } from "@/lib/compare-utils";
+import { formatKpiValue } from "@/lib/formatters";
+import type { CompareCompanyOption } from "@/lib/compare-page-data";
+
+type CompareKpiTableProps = {
+  companies: CompareCompanyOption[];
+  rows: CompareKpiRow[];
+  referenceYear: number;
+};
+
+function formatDeltaVsBase(
+  value: number | null,
+  formatType: string,
+): string {
+  if (value === null || Number.isNaN(value)) {
+    return "Sem base comparavel";
+  }
+
+  const signal = value >= 0 ? "+" : "";
+  if (formatType === "pct") {
+    return `${signal}${(value * 100).toFixed(1)} pp vs base`;
+  }
+
+  return `${signal}${value.toFixed(2)}x vs base`;
+}
+
+export function CompareKpiTable({
+  companies,
+  rows,
+  referenceYear,
+}: CompareKpiTableProps) {
+  return (
+    <section id="resultado-comparacao" className="space-y-4 scroll-mt-28">
+      <SectionHeading
+        eyebrow="Resultado"
+        title={`Comparacao lado a lado (${referenceYear})`}
+        titleAs="h2"
+        description="A primeira empresa da selecao vira a base de referencia para os deltas exibidos nas demais colunas."
+        descriptionClassName="text-sm leading-7"
+      />
+
+      <SurfaceCard tone="default" padding="none" className="overflow-hidden">
+        <Table>
+          <TableHeader className="bg-muted/35">
+            <TableRow>
+              <TableHead className="sticky left-0 z-20 bg-muted/35 px-5">Indicador</TableHead>
+              {companies.map((company, index) => (
+                <TableHead key={company.cd_cvm} className="min-w-64">
+                  <div className="space-y-1">
+                    <Link
+                      href={`/empresas/${company.cd_cvm}`}
+                      className="font-medium text-foreground hover:underline"
+                    >
+                      {company.company_name}
+                    </Link>
+                    <p className="text-[0.65rem] uppercase tracking-[0.16em] text-muted-foreground">
+                      {company.ticker_b3 ?? "sem ticker"} - CVM {company.cd_cvm}
+                      {index === 0 ? " - base" : ""}
+                    </p>
+                  </div>
+                </TableHead>
+              ))}
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {rows.map((row) => (
+              <TableRow key={row.kpiId}>
+                <TableCell className="sticky left-0 z-10 bg-background px-5">
+                  <div className="space-y-1">
+                    <p className="font-medium text-foreground">{row.label}</p>
+                    <p className="text-[0.68rem] uppercase tracking-[0.15em] text-muted-foreground">
+                      {row.kpiId}
+                    </p>
+                  </div>
+                </TableCell>
+                {row.cells.map((cell, index) => (
+                  <TableCell key={`${row.kpiId}-${companies[index]?.cd_cvm ?? index}`}>
+                    <div className="space-y-1">
+                      <p className="font-semibold text-foreground">
+                        {formatKpiValue(cell.value, cell.formatType || row.formatType)}
+                      </p>
+                      <p className="text-xs text-muted-foreground">
+                        {index === 0
+                          ? "Base de referencia"
+                          : formatDeltaVsBase(cell.deltaVsBase, cell.formatType || row.formatType)}
+                      </p>
+                    </div>
+                  </TableCell>
+                ))}
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </SurfaceCard>
+    </section>
+  );
+}

--- a/apps/web/components/compare/compare-selector.tsx
+++ b/apps/web/components/compare/compare-selector.tsx
@@ -1,0 +1,402 @@
+"use client";
+
+import Link from "next/link";
+import { PlusIcon, SearchIcon, XIcon } from "lucide-react";
+import {
+  startTransition,
+  useDeferredValue,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+
+import { InfoChip, SurfaceCard } from "@/components/shared/design-system-recipes";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Button, buttonVariants } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { serializeCompanyIds } from "@/lib/compare-utils";
+import type { CompanyDirectoryItem } from "@/lib/api";
+import { formatYearsLabel } from "@/lib/formatters";
+import type { CompareCompanyOption } from "@/lib/compare-page-data";
+import { mergeSearchParams, serializeYears } from "@/lib/search-params";
+import { track } from "@/lib/track";
+import { cn } from "@/lib/utils";
+
+type CompareSelectorProps = {
+  pathname: string;
+  selectedCompanies: CompareCompanyOption[];
+  quickCompanies: CompareCompanyOption[];
+  availableYears: number[];
+  selectedYears: number[];
+  maxCompanies?: number;
+};
+
+type SuggestionResponse = {
+  items?: CompanyDirectoryItem[];
+  error?: string;
+};
+
+const DEFAULT_MAX_COMPANIES = 5;
+
+function toCompareOption(item: CompanyDirectoryItem): CompareCompanyOption {
+  return {
+    cd_cvm: item.cd_cvm,
+    company_name: item.company_name,
+    ticker_b3: item.ticker_b3,
+    sector_name: item.sector_name,
+  };
+}
+
+export function CompareSelector({
+  pathname,
+  selectedCompanies,
+  quickCompanies,
+  availableYears,
+  selectedYears,
+  maxCompanies = DEFAULT_MAX_COMPANIES,
+}: CompareSelectorProps) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const [query, setQuery] = useState("");
+  const [suggestions, setSuggestions] = useState<CompareCompanyOption[]>([]);
+  const [loadingSuggestions, setLoadingSuggestions] = useState(false);
+  const [suggestionError, setSuggestionError] = useState<string | null>(null);
+  const deferredQuery = useDeferredValue(query);
+
+  const selectedIds = useMemo(
+    () => selectedCompanies.map((company) => company.cd_cvm),
+    [selectedCompanies],
+  );
+  const selectedIdSet = useMemo(
+    () => new Set(selectedIds),
+    [selectedIds],
+  );
+
+  useEffect(() => {
+    const normalized = deferredQuery.trim();
+
+    if (normalized.length < 2 || selectedCompanies.length >= maxCompanies) {
+      setSuggestions([]);
+      setSuggestionError(null);
+      return;
+    }
+
+    let active = true;
+    const timer = window.setTimeout(async () => {
+      setLoadingSuggestions(true);
+      setSuggestionError(null);
+
+      try {
+        const response = await fetch(
+          `/api/company-search?q=${encodeURIComponent(normalized)}`,
+          { cache: "no-store" },
+        );
+        const payload = (await response.json()) as SuggestionResponse;
+
+        if (!active) {
+          return;
+        }
+
+        if (!response.ok) {
+          setSuggestions([]);
+          setSuggestionError(payload.error ?? "Nao foi possivel buscar sugestoes.");
+          return;
+        }
+
+        const nextSuggestions = (payload.items ?? [])
+          .map(toCompareOption)
+          .filter((item) => !selectedIdSet.has(item.cd_cvm));
+
+        setSuggestions(nextSuggestions);
+      } catch {
+        if (!active) {
+          return;
+        }
+        setSuggestions([]);
+        setSuggestionError("Nao foi possivel buscar sugestoes.");
+      } finally {
+        if (active) {
+          setLoadingSuggestions(false);
+        }
+      }
+    }, 180);
+
+    return () => {
+      active = false;
+      window.clearTimeout(timer);
+    };
+  }, [deferredQuery, maxCompanies, selectedCompanies.length, selectedIdSet]);
+
+  function pushSelection(nextIds: number[], nextYears: number[] | null) {
+    const queryString = mergeSearchParams(searchParams.toString(), {
+      ids: nextIds.length > 0 ? serializeCompanyIds(nextIds) : null,
+      anos:
+        nextYears === null
+          ? null
+          : nextYears.length > 0
+            ? serializeYears(nextYears)
+            : null,
+    });
+
+    const href = queryString ? `${pathname}?${queryString}` : pathname;
+
+    startTransition(() => {
+      router.push(href);
+    });
+  }
+
+  function addCompany(company: CompareCompanyOption) {
+    if (selectedIdSet.has(company.cd_cvm)) {
+      return;
+    }
+
+    if (selectedIds.length >= maxCompanies) {
+      setSuggestionError(`Limite de ${maxCompanies} empresas nesta fase.`);
+      return;
+    }
+
+    const nextIds = [...selectedIds, company.cd_cvm];
+
+    track("compare_company_selected", {
+      cd_cvm: company.cd_cvm,
+      company_name: company.company_name,
+      selected_count: nextIds.length,
+    });
+
+    setQuery("");
+    setSuggestions([]);
+    setSuggestionError(null);
+    pushSelection(nextIds, null);
+  }
+
+  function removeCompany(cdCvm: number) {
+    const nextIds = selectedIds.filter((id) => id !== cdCvm);
+
+    track("compare_company_removed", {
+      cd_cvm: cdCvm,
+      selected_count: nextIds.length,
+    });
+
+    pushSelection(nextIds, null);
+  }
+
+  function toggleYear(year: number) {
+    const currentYears = new Set(selectedYears);
+
+    if (currentYears.has(year)) {
+      if (currentYears.size === 1) {
+        return;
+      }
+      currentYears.delete(year);
+    } else {
+      currentYears.add(year);
+    }
+
+    const nextYears = Array.from(currentYears).sort((left, right) => left - right);
+
+    track("compare_years_changed", {
+      years: nextYears.join(","),
+      selected_companies: selectedIds.length,
+    });
+
+    pushSelection(selectedIds, nextYears);
+  }
+
+  function adjustComparison() {
+    track("compare_adjust_clicked", {
+      selected_companies: selectedIds.length,
+      years: selectedYears.join(","),
+    });
+
+    pushSelection(selectedIds, selectedYears);
+  }
+
+  const quickOptions = quickCompanies.filter(
+    (company) => !selectedIdSet.has(company.cd_cvm),
+  );
+
+  return (
+    <SurfaceCard tone="subtle" padding="md" className="space-y-5">
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+        <div className="space-y-2">
+          <p className="text-xs uppercase tracking-[0.26em] text-muted-foreground">
+            Selecao da comparacao
+          </p>
+          <p className="text-sm leading-7 text-muted-foreground">
+            Escolha entre 2 e {maxCompanies} empresas para comparar os indicadores no mesmo periodo.
+          </p>
+        </div>
+        <InfoChip tone="muted">
+          {selectedIds.length}/{maxCompanies} empresas
+        </InfoChip>
+      </div>
+
+      <div className="space-y-3">
+        <div className="flex flex-col gap-2">
+          <div className="flex flex-1 items-center gap-3 rounded-[1.15rem] border border-border/65 bg-muted/55 px-4 py-3">
+            <SearchIcon className="size-4 text-muted-foreground" />
+            <Input
+              type="search"
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              placeholder="Buscar empresa para adicionar"
+              className="h-auto border-0 bg-transparent p-0 shadow-none focus-visible:ring-0"
+              aria-label="Buscar empresa para comparar"
+            />
+          </div>
+          <p className="text-xs text-muted-foreground">
+            Digite ao menos 2 caracteres para receber sugestoes e adicionar empresas.
+          </p>
+        </div>
+
+        {loadingSuggestions ? (
+          <p className="text-sm text-muted-foreground">Buscando sugestoes...</p>
+        ) : null}
+
+        {suggestionError ? (
+          <Alert className="rounded-2xl border border-destructive/20 bg-destructive/6 px-4 py-3">
+            <AlertTitle>Busca de empresa indisponivel</AlertTitle>
+            <AlertDescription>{suggestionError}</AlertDescription>
+          </Alert>
+        ) : null}
+
+        {suggestions.length > 0 ? (
+          <div className="grid gap-2 sm:grid-cols-2">
+            {suggestions.map((item) => (
+              <button
+                key={item.cd_cvm}
+                type="button"
+                data-testid="compare-suggestion-add"
+                className="flex items-center justify-between rounded-[1rem] border border-border/65 bg-background/90 px-4 py-3 text-left transition-colors hover:bg-muted/45"
+                onClick={() => addCompany(item)}
+              >
+                <span className="space-y-1">
+                  <span className="block text-sm font-medium text-foreground">{item.company_name}</span>
+                  <span className="block text-xs text-muted-foreground">
+                    {item.ticker_b3 ?? "Sem ticker"} - CVM {item.cd_cvm}
+                  </span>
+                </span>
+                <PlusIcon className="size-4 text-muted-foreground" />
+              </button>
+            ))}
+          </div>
+        ) : null}
+
+        {quickOptions.length > 0 && selectedIds.length < maxCompanies ? (
+          <div className="space-y-2">
+            <p className="text-xs uppercase tracking-[0.22em] text-muted-foreground">Sugestoes rapidas</p>
+            <div className="flex flex-wrap gap-2">
+              {quickOptions.slice(0, 6).map((company) => (
+                <button
+                  key={company.cd_cvm}
+                  type="button"
+                  data-testid="compare-quick-add"
+                  className={cn(
+                    buttonVariants({ variant: "outline", size: "sm" }),
+                    "rounded-full px-3",
+                  )}
+                  onClick={() => addCompany(company)}
+                >
+                  {company.company_name}
+                </button>
+              ))}
+            </div>
+          </div>
+        ) : null}
+      </div>
+
+      <div className="space-y-3">
+        <p className="text-xs uppercase tracking-[0.22em] text-muted-foreground">Empresas selecionadas</p>
+        {selectedCompanies.length === 0 ? (
+          <p className="text-sm text-muted-foreground">Nenhuma empresa selecionada ainda.</p>
+        ) : (
+          <div className="flex flex-wrap gap-2">
+            {selectedCompanies.map((company) => (
+              <div
+                key={company.cd_cvm}
+                data-testid="compare-selected-chip"
+                className="inline-flex items-center gap-2 rounded-full border border-border/70 bg-background/88 px-3 py-1.5 text-sm"
+              >
+                <Link
+                  href={`/empresas/${company.cd_cvm}`}
+                  className="font-medium text-foreground hover:underline"
+                >
+                  {company.company_name}
+                </Link>
+                <span className="text-xs text-muted-foreground">{company.ticker_b3 ?? "-"}</span>
+                <button
+                  type="button"
+                  onClick={() => removeCompany(company.cd_cvm)}
+                  className="inline-flex size-5 items-center justify-center rounded-full text-muted-foreground hover:bg-muted hover:text-foreground"
+                  aria-label={`Remover ${company.company_name}`}
+                >
+                  <XIcon className="size-3.5" />
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <div className="space-y-3">
+        <p className="text-xs uppercase tracking-[0.22em] text-muted-foreground">Periodo em comum</p>
+        {availableYears.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            As empresas atuais nao possuem anos em comum para comparacao.
+          </p>
+        ) : (
+          <>
+            <div className="flex flex-wrap items-center gap-2">
+              {availableYears.map((year) => {
+                const active = selectedYears.includes(year);
+                return (
+                  <Button
+                    key={year}
+                    type="button"
+                    variant={active ? "secondary" : "outline"}
+                    size="sm"
+                    className="rounded-full px-4"
+                    onClick={() => toggleYear(year)}
+                  >
+                    {year}
+                  </Button>
+                );
+              })}
+            </div>
+            <p className="text-xs text-muted-foreground">
+              Janela selecionada: {formatYearsLabel(selectedYears)}
+            </p>
+          </>
+        )}
+      </div>
+
+      <div className="flex flex-wrap items-center gap-3">
+        <Button
+          type="button"
+          size="lg"
+          className="rounded-full px-5"
+          onClick={adjustComparison}
+          disabled={selectedIds.length < 2 || selectedYears.length === 0}
+        >
+          Ajustar comparacao
+        </Button>
+        <button
+          type="button"
+          className={cn(buttonVariants({ variant: "outline", size: "lg" }), "rounded-full px-5")}
+          onClick={() => {
+            track("compare_reset_clicked", {
+              selected_companies: selectedIds.length,
+            });
+            startTransition(() => {
+              router.push(pathname);
+            });
+          }}
+        >
+          Limpar selecao
+        </button>
+      </div>
+    </SurfaceCard>
+  );
+}

--- a/apps/web/components/compare/compare-tracker.tsx
+++ b/apps/web/components/compare/compare-tracker.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { useEffect } from "react";
+
+import { track } from "@/lib/track";
+
+type CompareTrackerProps = {
+  companyIds: number[];
+  years: number[];
+  comparableCompanies: number;
+};
+
+export function CompareTracker({
+  companyIds,
+  years,
+  comparableCompanies,
+}: CompareTrackerProps) {
+  useEffect(() => {
+    track("compare_viewed", {
+      companies_selected: companyIds.length,
+      companies_comparable: comparableCompanies,
+      ids: companyIds.join(","),
+      years: years.join(","),
+    });
+  }, [companyIds, comparableCompanies, years]);
+
+  return null;
+}

--- a/apps/web/components/home/future-domain-grid.tsx
+++ b/apps/web/components/home/future-domain-grid.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { ArrowUpRightIcon } from "lucide-react";
 
 import {
@@ -19,16 +20,28 @@ export function FutureDomainGrid() {
           <div className="space-y-4">
             <div className="flex items-center justify-between gap-3">
               <h2 className="font-heading text-xl text-foreground">{item.label}</h2>
-              <InfoChip tone="muted">Em breve</InfoChip>
+              <InfoChip tone={item.status === "disponivel" ? "brand" : "muted"}>
+                {item.status === "disponivel" ? "Disponivel" : "Em breve"}
+              </InfoChip>
             </div>
             <p className="text-sm leading-7 text-muted-foreground">
               {item.description}
             </p>
           </div>
-          <div className="flex items-center gap-2 text-xs uppercase tracking-[0.2em] text-muted-foreground">
-            Aguardando proximos contratos
-            <ArrowUpRightIcon className="size-3.5" />
-          </div>
+          {item.href ? (
+            <Link
+              href={item.href}
+              className="flex items-center gap-2 text-xs uppercase tracking-[0.2em] text-foreground transition-colors hover:text-primary"
+            >
+              Abrir superficie
+              <ArrowUpRightIcon className="size-3.5" />
+            </Link>
+          ) : (
+            <div className="flex items-center gap-2 text-xs uppercase tracking-[0.2em] text-muted-foreground">
+              Aguardando proximos contratos
+              <ArrowUpRightIcon className="size-3.5" />
+            </div>
+          )}
         </SurfaceCard>
       ))}
     </section>

--- a/apps/web/components/shared/site-footer.tsx
+++ b/apps/web/components/shared/site-footer.tsx
@@ -6,7 +6,7 @@ const SITEMAP = [
     links: [
       { label: "Home", href: "/" },
       { label: "Empresas", href: "/empresas" },
-      { label: "Comparar", href: null },
+      { label: "Comparar", href: "/comparar" },
       { label: "Setores", href: null },
     ],
   },
@@ -47,7 +47,7 @@ export function SiteFooter() {
             </p>
             <p className="mt-2 text-sm leading-7 text-muted-foreground">
               V2 web como camada read-only sobre a API estabilizada. Fluxos de
-              refresh, comparacao e dominios setoriais entram nas proximas fases.
+              refresh e dominios setoriais entram nas proximas fases.
             </p>
           </div>
 

--- a/apps/web/components/shared/site-header.tsx
+++ b/apps/web/components/shared/site-header.tsx
@@ -6,7 +6,7 @@ import { cn } from "@/lib/utils";
 const PRIMARY_NAV = [
   { label: "Home", href: "/" },
   { label: "Empresas", href: "/empresas" },
-  { label: "Comparar", href: null },
+  { label: "Comparar", href: "/comparar" },
   { label: "Setores", href: null },
   { label: "KPIs", href: null },
   { label: "Macro", href: null },

--- a/apps/web/lib/compare-page-data.ts
+++ b/apps/web/lib/compare-page-data.ts
@@ -1,0 +1,201 @@
+import {
+  fetchCompanyInfo,
+  fetchCompanyKpis,
+  fetchCompanyYears,
+  getUserFacingErrorMessage,
+  type CompanyInfo,
+} from "@/lib/api";
+import {
+  buildFeaturedCompareRows,
+  intersectYears,
+  parseCompanyIdsCsv,
+  type CompareCompanyBundle,
+  type CompareKpiRow,
+} from "@/lib/compare-utils";
+import { normalizeSelectedYears } from "@/lib/search-params";
+
+export type CompareCompanyOption = {
+  cd_cvm: number;
+  company_name: string;
+  ticker_b3: string | null;
+  sector_name: string;
+};
+
+export type ComparePageData = {
+  selectedCompanies: CompareCompanyOption[];
+  comparedCompanies: CompareCompanyOption[];
+  availableYears: number[];
+  selectedYears: number[];
+  referenceYear: number | null;
+  rows: CompareKpiRow[];
+  dataError: string | null;
+  partialErrors: string[];
+};
+
+function toCompareOption(company: CompanyInfo): CompareCompanyOption {
+  return {
+    cd_cvm: company.cd_cvm,
+    company_name: company.company_name,
+    ticker_b3: company.ticker_b3,
+    sector_name: company.sector_name,
+  };
+}
+
+const EMPTY_RESULT: ComparePageData = {
+  selectedCompanies: [],
+  comparedCompanies: [],
+  availableYears: [],
+  selectedYears: [],
+  referenceYear: null,
+  rows: [],
+  dataError: null,
+  partialErrors: [],
+};
+
+export async function loadComparePageData(
+  rawIds: string | undefined,
+  rawYears: string | undefined,
+): Promise<ComparePageData> {
+  const ids = parseCompanyIdsCsv(rawIds);
+  if (ids.length === 0) {
+    return EMPTY_RESULT;
+  }
+
+  const partialErrors: string[] = [];
+  const infoResults = await Promise.allSettled(ids.map((id) => fetchCompanyInfo(id)));
+
+  const selectedCompanyInfo: CompanyInfo[] = [];
+
+  infoResults.forEach((result, index) => {
+    const requestedId = ids[index];
+
+    if (result.status === "fulfilled") {
+      if (result.value) {
+        selectedCompanyInfo.push(result.value);
+      } else {
+        partialErrors.push(`Empresa ${requestedId} nao encontrada.`);
+      }
+      return;
+    }
+
+    partialErrors.push(getUserFacingErrorMessage(result.reason));
+  });
+
+  if (selectedCompanyInfo.length === 0) {
+    return {
+      ...EMPTY_RESULT,
+      dataError: "Nao foi possivel carregar as empresas selecionadas.",
+      partialErrors,
+    };
+  }
+
+  const selectedCompanies = selectedCompanyInfo.map(toCompareOption);
+
+  if (selectedCompanies.length < 2) {
+    return {
+      ...EMPTY_RESULT,
+      selectedCompanies,
+      partialErrors,
+    };
+  }
+
+  const yearsResults = await Promise.allSettled(
+    selectedCompanyInfo.map((company) => fetchCompanyYears(company.cd_cvm)),
+  );
+
+  const yearGroups: number[][] = [];
+
+  yearsResults.forEach((result, index) => {
+    const company = selectedCompanyInfo[index];
+
+    if (result.status === "fulfilled") {
+      if (result.value.length === 0) {
+        partialErrors.push(`A empresa ${company.company_name} nao possui anos disponiveis.`);
+        return;
+      }
+      yearGroups.push(result.value);
+      return;
+    }
+
+    partialErrors.push(
+      `Nao foi possivel carregar os anos de ${company.company_name}: ${getUserFacingErrorMessage(result.reason)}`,
+    );
+  });
+
+  const availableYears = intersectYears(yearGroups);
+  const selectedYears = normalizeSelectedYears(availableYears, rawYears);
+
+  if (availableYears.length === 0) {
+    return {
+      ...EMPTY_RESULT,
+      selectedCompanies,
+      availableYears,
+      selectedYears,
+      partialErrors,
+      dataError:
+        "As empresas selecionadas nao possuem anos em comum para comparacao. Ajuste a selecao.",
+    };
+  }
+
+  if (selectedYears.length === 0) {
+    return {
+      ...EMPTY_RESULT,
+      selectedCompanies,
+      availableYears,
+      selectedYears,
+      partialErrors,
+      dataError: "Nao foi possivel resolver um periodo valido para comparacao.",
+    };
+  }
+
+  const kpiResults = await Promise.allSettled(
+    selectedCompanyInfo.map((company) => fetchCompanyKpis(company.cd_cvm, selectedYears)),
+  );
+
+  const comparedBundles: CompareCompanyBundle[] = [];
+
+  kpiResults.forEach((result, index) => {
+    const company = selectedCompanyInfo[index];
+
+    if (result.status === "fulfilled") {
+      comparedBundles.push({
+        company,
+        bundle: result.value,
+      });
+      return;
+    }
+
+    partialErrors.push(
+      `Nao foi possivel carregar os KPIs de ${company.company_name}: ${getUserFacingErrorMessage(result.reason)}`,
+    );
+  });
+
+  if (comparedBundles.length < 2) {
+    return {
+      ...EMPTY_RESULT,
+      selectedCompanies,
+      availableYears,
+      selectedYears,
+      partialErrors,
+      dataError:
+        "A comparacao precisa de pelo menos duas empresas com dados de KPI disponiveis no periodo.",
+    };
+  }
+
+  const referenceYear = selectedYears[selectedYears.length - 1] ?? null;
+  const rows =
+    referenceYear === null
+      ? []
+      : buildFeaturedCompareRows(comparedBundles, referenceYear);
+
+  return {
+    ...EMPTY_RESULT,
+    selectedCompanies,
+    comparedCompanies: comparedBundles.map((entry) => toCompareOption(entry.company)),
+    availableYears,
+    selectedYears,
+    referenceYear,
+    rows,
+    partialErrors,
+  };
+}

--- a/apps/web/lib/compare-utils.ts
+++ b/apps/web/lib/compare-utils.ts
@@ -1,0 +1,145 @@
+import type { CompanyInfo, KPIBundle, TabularDataRow } from "./api.ts";
+import { FEATURED_KPIS } from "./constants.ts";
+
+const DEFAULT_MAX_COMPANIES = 5;
+
+type NumberLike = number | string | null | undefined;
+
+export type CompareCompanyBundle = {
+  company: CompanyInfo;
+  bundle: KPIBundle;
+};
+
+export type CompareKpiCell = {
+  value: number | null;
+  deltaVsBase: number | null;
+  formatType: string;
+};
+
+export type CompareKpiRow = {
+  kpiId: string;
+  label: string;
+  formatType: string;
+  cells: CompareKpiCell[];
+};
+
+function coerceFiniteNumber(value: NumberLike): number | null {
+  if (value === null || value === undefined) {
+    return null;
+  }
+
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) {
+    return null;
+  }
+
+  return parsed;
+}
+
+function buildAnnualIndex(bundle: KPIBundle): Map<string, TabularDataRow> {
+  const index = new Map<string, TabularDataRow>();
+
+  bundle.annual.rows.forEach((row) => {
+    const kpiId = String((row as TabularDataRow).KPI_ID ?? "").trim();
+    if (!kpiId) {
+      return;
+    }
+    index.set(kpiId, row as TabularDataRow);
+  });
+
+  return index;
+}
+
+export function parseCompanyIdsCsv(
+  value: string | undefined,
+  maxCompanies = DEFAULT_MAX_COMPANIES,
+): number[] {
+  if (!value) {
+    return [];
+  }
+
+  const uniqueIds = Array.from(
+    new Set(
+      value
+        .split(",")
+        .map((token) => Number.parseInt(token.trim(), 10))
+        .filter((id) => Number.isFinite(id) && id > 0),
+    ),
+  );
+
+  return uniqueIds.slice(0, maxCompanies);
+}
+
+export function serializeCompanyIds(ids: number[]): string {
+  return Array.from(new Set(ids.filter((id) => Number.isFinite(id) && id > 0))).join(",");
+}
+
+export function intersectYears(yearGroups: number[][]): number[] {
+  if (yearGroups.length === 0) {
+    return [];
+  }
+
+  const normalized = yearGroups
+    .map((years) =>
+      Array.from(
+        new Set(
+          years
+            .map((year) => Number.parseInt(String(year), 10))
+            .filter((year) => Number.isFinite(year)),
+        ),
+      ).sort((left, right) => left - right),
+    )
+    .filter((years) => years.length > 0);
+
+  if (normalized.length === 0) {
+    return [];
+  }
+
+  return normalized.slice(1).reduce((acc, years) => {
+    const yearSet = new Set(years);
+    return acc.filter((year) => yearSet.has(year));
+  }, normalized[0]);
+}
+
+export function buildFeaturedCompareRows(
+  companies: CompareCompanyBundle[],
+  referenceYear: number,
+): CompareKpiRow[] {
+  if (companies.length === 0) {
+    return [];
+  }
+
+  const annualIndices = companies.map((entry) => buildAnnualIndex(entry.bundle));
+
+  return FEATURED_KPIS.map((kpi) => {
+    const cells = annualIndices.map((index, companyIndex) => {
+      const row = index.get(kpi.id);
+      const formatType = String(row?.FORMAT_TYPE ?? kpi.formatType);
+      const value = coerceFiniteNumber(row?.[String(referenceYear)] as NumberLike);
+
+      let deltaVsBase: number | null = null;
+      if (companyIndex > 0) {
+        const baseRow = annualIndices[0].get(kpi.id);
+        const baseValue = coerceFiniteNumber(baseRow?.[String(referenceYear)] as NumberLike);
+        if (value !== null && baseValue !== null) {
+          deltaVsBase = value - baseValue;
+        }
+      }
+
+      return {
+        value,
+        deltaVsBase,
+        formatType,
+      } satisfies CompareKpiCell;
+    });
+
+    const preferredFormat = cells.find((cell) => Boolean(cell.formatType))?.formatType ?? kpi.formatType;
+
+    return {
+      kpiId: kpi.id,
+      label: kpi.label,
+      formatType: preferredFormat,
+      cells,
+    } satisfies CompareKpiRow;
+  });
+}

--- a/apps/web/lib/constants.ts
+++ b/apps/web/lib/constants.ts
@@ -2,18 +2,26 @@ export const HOME_QUICK_LINKS = [
   {
     label: "Comparar",
     description: "Comparacao lado a lado entre empresas e contextos setoriais.",
+    href: "/comparar",
+    status: "disponivel",
   },
   {
     label: "Setores",
     description: "Leitura tematica por clusters e cadeias produtivas.",
+    href: null,
+    status: "em-breve",
   },
   {
     label: "KPIs",
     description: "Catalogo navegavel dos indicadores-chave da plataforma.",
+    href: null,
+    status: "em-breve",
   },
   {
     label: "Macro",
     description: "Contexto macroeconomico para leitura dos resultados.",
+    href: null,
+    status: "em-breve",
   },
 ] as const;
 

--- a/apps/web/lib/track.ts
+++ b/apps/web/lib/track.ts
@@ -5,7 +5,13 @@ export type TrackEventName =
   | "companies_pagination_clicked"
   | "company_detail_viewed"
   | "company_years_changed"
-  | "company_statement_changed";
+  | "company_statement_changed"
+  | "compare_viewed"
+  | "compare_company_selected"
+  | "compare_company_removed"
+  | "compare_years_changed"
+  | "compare_adjust_clicked"
+  | "compare_reset_clicked";
 
 type TrackPayload = Record<string, string | number | boolean | null | undefined>;
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -8,7 +8,7 @@
     "start": "next start",
     "lint": "eslint",
     "typecheck": "tsc --noEmit",
-    "test:unit": "node --experimental-strip-types --experimental-specifier-resolution=node --test tests/api-client.test.ts tests/companies-page-data.test.ts",
+    "test:unit": "node --experimental-strip-types --experimental-specifier-resolution=node --test tests/api-client.test.ts tests/companies-page-data.test.ts tests/compare-utils.test.ts",
     "test:e2e": "playwright test"
   },
   "dependencies": {

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -4,6 +4,7 @@ import { defineConfig } from "@playwright/test";
 export default defineConfig({
   testDir: "./tests",
   testMatch: "**/*.spec.ts",
+  workers: 1,
   timeout: 45_000,
   use: {
     baseURL: "http://127.0.0.1:3000",

--- a/apps/web/tests/compare-utils.test.ts
+++ b/apps/web/tests/compare-utils.test.ts
@@ -1,0 +1,90 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  buildFeaturedCompareRows,
+  intersectYears,
+  parseCompanyIdsCsv,
+} from "../lib/compare-utils.ts";
+import type { CompanyInfo, KPIBundle } from "../lib/api.ts";
+
+function buildCompany(
+  cdCvm: number,
+  name: string,
+  ticker: string,
+): CompanyInfo {
+  return {
+    cd_cvm: cdCvm,
+    company_name: name,
+    nome_comercial: name,
+    cnpj: null,
+    setor_cvm: "Energia",
+    setor_analitico: "Energia",
+    sector_name: "Energia",
+    sector_slug: "energia",
+    company_type: "comercial",
+    ticker_b3: ticker,
+  };
+}
+
+function buildBundle(cdCvm: number, margin: number): KPIBundle {
+  return {
+    cd_cvm: cdCvm,
+    years: [2024],
+    annual: {
+      columns: ["KPI_ID", "KPI_NOME", "FORMAT_TYPE", "2024"],
+      rows: [
+        {
+          KPI_ID: "MG_BRUTA",
+          KPI_NOME: "Margem Bruta",
+          FORMAT_TYPE: "pct",
+          "2024": margin,
+        },
+      ],
+    },
+    quarterly: {
+      columns: [],
+      rows: [],
+    },
+  };
+}
+
+test("parseCompanyIdsCsv dedupes ids and keeps positive values", () => {
+  const parsed = parseCompanyIdsCsv("9512,9512,0,-7,1179,abc,347");
+
+  assert.deepEqual(parsed, [9512, 1179, 347]);
+});
+
+test("intersectYears returns sorted overlap across all groups", () => {
+  const years = intersectYears([
+    [2021, 2022, 2023, 2024],
+    [2020, 2022, 2024],
+    [2022, 2024, 2025],
+  ]);
+
+  assert.deepEqual(years, [2022, 2024]);
+});
+
+test("buildFeaturedCompareRows computes delta against the first company", () => {
+  const rows = buildFeaturedCompareRows(
+    [
+      {
+        company: buildCompany(9512, "PETROBRAS", "PETR4"),
+        bundle: buildBundle(9512, 0.42),
+      },
+      {
+        company: buildCompany(1179, "VALE", "VALE3"),
+        bundle: buildBundle(1179, 0.37),
+      },
+    ],
+    2024,
+  );
+
+  const grossMargin = rows.find((row) => row.kpiId === "MG_BRUTA");
+
+  assert.ok(grossMargin);
+  assert.equal(grossMargin?.cells[0].value, 0.42);
+  assert.equal(grossMargin?.cells[1].value, 0.37);
+  assert.ok(grossMargin?.cells[1].deltaVsBase !== null);
+  assert.ok(Math.abs((grossMargin?.cells[1].deltaVsBase ?? 0) + 0.05) < 1e-9);
+});

--- a/apps/web/tests/compare.spec.ts
+++ b/apps/web/tests/compare.spec.ts
@@ -1,0 +1,33 @@
+import { expect, test } from "@playwright/test";
+
+test("fluxo inicial de comparacao entre empresas", async ({ page }) => {
+  await page.goto("/comparar");
+
+  await expect(
+    page.getByRole("heading", {
+      name: /comparacao de empresas/i,
+    }),
+  ).toBeVisible();
+
+  const quickAddButtons = page
+    .getByTestId("compare-quick-add")
+    .filter({ hasNotText: /^--$/ });
+  await expect(quickAddButtons.first()).toBeVisible({ timeout: 15_000 });
+
+  await quickAddButtons.first().click();
+  await expect(page).toHaveURL(/\/comparar\?ids=\d+/i, {
+    timeout: 30_000,
+  });
+
+  const secondRoundButtons = page
+    .getByTestId("compare-quick-add")
+    .filter({ hasNotText: /^--$/ });
+  await expect(secondRoundButtons.first()).toBeVisible({ timeout: 15_000 });
+  await secondRoundButtons.first().click();
+
+  await expect(page).toHaveURL(/\/comparar\?ids=\d+(%2C|,)\d+/i, {
+    timeout: 30_000,
+  });
+  await expect(page.locator("#resultado-comparacao")).toBeVisible({ timeout: 30_000 });
+  await expect(page.locator("#resultado-comparacao table")).toBeVisible();
+});

--- a/apps/web/tests/smoke.spec.ts
+++ b/apps/web/tests/smoke.spec.ts
@@ -13,12 +13,16 @@ test("fluxo inicial de descoberta por empresa", async ({ page }) => {
     .getByRole("searchbox", { name: /buscar empresa/i })
     .fill("petrobras");
 
-  await page.getByRole("button", { name: /buscar empresa/i }).click();
+  await page
+    .getByRole("searchbox", { name: /buscar empresa/i })
+    .press("Enter");
 
-  await expect(page).toHaveURL(/\/empresas\?busca=petrobras/i);
+  await expect(page).toHaveURL(/\/empresas\?busca=petrobras/i, {
+    timeout: 30_000,
+  });
   await expect(
     page.getByRole("heading", { name: /diretorio publico de empresas/i }),
-  ).toBeVisible({ timeout: 15_000 });
+  ).toBeVisible({ timeout: 30_000 });
 
   await expect(page.locator("article").first()).toContainText(/PETROBRAS/i);
   await page.getByRole("link", { name: /ver empresa/i }).first().click();


### PR DESCRIPTION
## Summary
- deliver PG-04 compare route at `/comparar`
- add compare domain components (selector, KPI comparison table, tracker)
- add compare data/loading utilities and URL-state handling
- activate Compare navigation entry points (header, footer, home card, company detail CTA)
- add compare unit/e2e tests and harden smoke/e2e reliability in local stack

## Validation
- `cd apps/web && npm run typecheck`
- `cd apps/web && npm run test:unit`
- `cd apps/web && npm run test:e2e`
- `cd apps/web && npm run build`

## Scope notes
- frontend-only changes under `apps/web`
- no backend contract changes

Closes #25