### PR TITLE
[Task] Corrigir worktree_remove quando a base local estiver desatualizada

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -91,6 +91,12 @@
 
 ## Sessoes Recentes
 
+### Sessao 35 - 2026-04-08 (fix no helper de remocao de worktree)
+- `scripts/worktree_remove.ps1` deixa de quebrar quando o merge-check local
+  retorna vazio
+- sem `-Force`, o helper agora orienta atualizar `master` local ou usar
+  `-Force` quando o clone ainda nao enxerga o merge remoto
+
 ### Sessao 34 - 2026-04-08 (lanes oficiais, worktrees e critical paths)
 - O repositorio passa a operar com tres lanes oficiais:
   `lane:frontend`, `lane:backend` e `lane:ops-quality`

--- a/docs/governance/parallel-lanes.md
+++ b/docs/governance/parallel-lanes.md
@@ -107,6 +107,8 @@ Boas praticas:
 - abra uma segunda janela do editor para a worktree da task
 - nao reuse a mesma worktree para duas tasks diferentes
 - nao remova worktree com branch nao mergeada sem `-Force`
+- se o branch-base local estiver desatualizado, atualize o base ou use `-Force`;
+  o helper deve falhar com mensagem clara, nao com erro interno do PowerShell
 
 ## Exemplos
 

--- a/scripts/worktree_remove.ps1
+++ b/scripts/worktree_remove.ps1
@@ -35,9 +35,15 @@ if (-not (Test-Path $worktreePath)) {
 }
 
 if (-not $Force) {
-  $merged = (git -C $repoRoot branch --merged $Base --list $branch).Trim()
-  if (-not $merged) {
-    throw "A branch $branch ainda nao aparece como mergeada em $Base. Use -Force para remover mesmo assim."
+  $mergedOutput = git -C $repoRoot branch --merged $Base --list $branch
+  $merged = @(
+    $mergedOutput |
+      ForEach-Object { "$_".Trim() } |
+      Where-Object { $_ }
+  )
+
+  if ($merged.Count -eq 0) {
+    throw "A branch $branch ainda nao aparece como mergeada em $Base no clone local. Rode git fetch/pull do base ou use -Force para remover mesmo assim."
   }
 }
 


### PR DESCRIPTION
﻿## Issue

Closes #29

## Resumo

- corrige `scripts/worktree_remove.ps1` para nao chamar `.Trim()` em retorno nulo do merge-check local
- passa a falhar com mensagem clara quando a branch ainda nao aparece como mergeada no base local
- registra o comportamento esperado em `docs/governance/parallel-lanes.md` e `docs/AGENTS.md`

## Paralelismo

- lane da task: `lane:ops-quality`
- worktree usada: `.claude/worktrees/ops-quality/29-fix-worktree-remove/`
- esta e a unica PR oficial da task: `sim`
- risco da task: `risk:shared`
- write-set principal: scripts/worktree_remove.ps1, docs/governance/parallel-lanes.md, docs/AGENTS.md
- coordenacao com outras tasks/PRs: nenhuma concorrencia relevante no momento

## Compatibilidade

- politica aplicada: `n/a`
- impacto em API, schema ou docs publicos: nenhum contrato de aplicacao alterado; apenas helper operacional de worktree

## Validacao

- [x] validacoes executadas e registradas abaixo

```text
powershell -ExecutionPolicy Bypass -File scripts\worktree_create.ps1 -Issue 29002 -Slug remove-smoke-origin -Lane ops-quality -Base origin/master
powershell -NoProfile -ExecutionPolicy Bypass -File scripts\worktree_remove.ps1 -Issue 29002 -Slug remove-smoke-origin -Lane ops-quality
powershell -ExecutionPolicy Bypass -File scripts\worktree_remove.ps1 -Issue 29002 -Slug remove-smoke-origin -Lane ops-quality -Force
git worktree prune --verbose
git diff --check
```

## Checklist

- [x] a branch segue `task/<issue-number>-<slug>`
- [x] a issue vinculada esta atualizada com checklist/status/evidencias
- [x] a issue vinculada registra owner atual, lane oficial, workspace da task, write-set esperado e `risk:*`
- [x] docs relevantes foram atualizados quando necessario
- [x] lane da task e worktree oficial foram registradas nesta PR
- [x] se a task for `risk:shared` ou `risk:contract-sensitive`, a PR abriu em draft
- [ ] se a task for `risk:contract-sensitive`, a compatibilidade foi revisada e documentada
- [x] PR em draft apenas enquanto o trabalho ou as validacoes ainda estiverem incompletos
- [ ] pronto para `squash merge` em `master` quando os checks estiverem verdes
