### PR TITLE
[Task] Garantir fechamento por checks verdes e merge confirmado

### DIFF
--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -132,6 +132,7 @@ body:
         - [ ] Implementacao concluida
         - [ ] Validacao executada
         - [ ] Issue/docs atualizados
+        - [ ] PR mergeada e issue fechada
     validations:
       required: true
   - type: textarea

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -38,4 +38,6 @@ Closes #
 - [ ] se a task for `risk:shared` ou `risk:contract-sensitive`, a PR abriu em draft
 - [ ] se a task for `risk:contract-sensitive`, a compatibilidade foi revisada e documentada
 - [ ] PR em draft apenas enquanto o trabalho ou as validacoes ainda estiverem incompletos
+- [ ] checks obrigatorios verdes ou helper de conclusao acionado para aguardar
 - [ ] pronto para `squash merge` em `master` quando os checks estiverem verdes
+- [ ] nao considerar a task concluida ate confirmar merge, issue fechada e branch remota removida quando aplicavel

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,8 +33,15 @@ repositorio.
    - a task usa branch `task/<issue-number>-<slug>`
    - a worktree vive em `.claude/worktrees/<lane>/<issue-number>-<slug>/`
 6. Abra PR com `Closes #<issue-number>` no corpo.
-7. Antes de encerrar, atualize checklist, evidencias e docs afetados.
-8. A task fecha com o merge da PR. Epics fecham manualmente.
+7. Quando a implementacao estiver pronta, conclua a task com
+   `scripts/pr_complete.ps1` ou processo equivalente:
+   - checks obrigatorios verdes;
+   - PR mergeada;
+   - issue fechada;
+   - branch remota removida quando aplicavel.
+8. Antes de encerrar, atualize checklist, evidencias e docs afetados.
+9. A task so conta como concluida depois do merge confirmado da PR. Epics fecham
+   manualmente.
 
 ## Regra de commit, push e merge
 
@@ -51,12 +58,13 @@ repositorio.
 - Quando a task estiver completa e as validacoes relevantes tiverem passado:
   - atualize a issue;
   - marque a PR como pronta;
-  - faca merge para `master` se nao houver bloqueio explicito do usuario.
+  - use `scripts/pr_complete.ps1 -Pr <numero>` ou fluxo equivalente para esperar
+    os checks e concluir o merge.
 - Preferencia de merge: `squash merge`.
 - Depois do merge:
   - confirme o fechamento da task;
   - remova a worktree da task;
-  - confirme que a branch remota sera removida automaticamente.
+  - confirme que a branch remota foi removida ou remova-a explicitamente.
 
 ## Lanes oficiais
 
@@ -121,5 +129,6 @@ duas lanes de produto, divida em child tasks separadas.
 - Atualize a issue com a evidencia principal.
 - Confirme que a PR referencia a mesma issue da branch.
 - Confirme que a worktree da task esta registrada na issue.
-- Se a branch estiver pronta, nao pare em "codigo feito": publique e finalize o
-  merge.
+- Nao pare com a PR apenas aberta: confirme checks verdes e merge real.
+- Confirme que a issue fechou e que a branch remota foi removida, quando
+  aplicavel.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,8 +22,9 @@ Before changing any versioned file:
 6. Keep the repo root stable on `master` and do not switch task branches in the main workspace.
 7. Work in a branch named `task/<issue-number>-<slug>`.
 8. Open a PR with `Closes #<issue-number>` in the body.
-9. Update the issue and relevant docs before considering the task complete.
-10. Commit validated checkpoints, push them promptly, and merge to `master` when the task is complete and checks are green unless the user explicitly says not to.
+9. Finish the task with `scripts/pr_complete.ps1 -Pr <number>` or an equivalent flow that waits for checks, confirms merge, verifies the linked issue is closed, and confirms the remote branch is gone when applicable.
+10. Update the issue and relevant docs before considering the task complete.
+11. Commit validated checkpoints, push them promptly, and merge to `master` when the task is complete and checks are green unless the user explicitly says not to.
 
 ## Publish and Merge Policy
 
@@ -34,7 +35,7 @@ Before changing any versioned file:
 - When acceptance criteria are satisfied and relevant checks pass:
   - update the issue;
   - mark the PR ready if needed;
-  - merge into `master`.
+  - use `scripts/pr_complete.ps1` or an equivalent flow to wait through green checks and complete the merge into `master`.
 - Prefer squash merge for short-lived Codex branches.
 - After merge, confirm the linked task closes and the remote branch is removed when possible.
 - Remove the linked task worktree after merge when it is no longer needed.

--- a/COMO_RODAR.md
+++ b/COMO_RODAR.md
@@ -45,6 +45,13 @@ editar arquivos:
 powershell -ExecutionPolicy Bypass -File scripts/worktree_create.ps1 -Issue 27 -Slug exemplo-task -Lane ops-quality
 ```
 
+Ao concluir a task, prefira finalizar a PR com o helper abaixo para esperar
+checks, mergear e confirmar o fechamento:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File scripts/pr_complete.ps1 -Pr 28
+```
+
 ---
 
 ## 2. Diagnosticar o runtime

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,8 @@
   `.claude/worktrees/<lane>/<issue-number>-<slug>/`.
 - O repo raiz permanece em `master`.
 - Abra PR com `Closes #<issue-number>`.
+- Quando a task estiver pronta, use `scripts/pr_complete.ps1 -Pr <numero>` ou
+  fluxo equivalente para esperar checks verdes e concluir o merge real.
 - Atualize checklist, status e evidencias na issue antes do merge.
 - Faca `commit` em checkpoints verificaveis, `push` ao finalizar um checkpoint
   remoto e `merge` para `master` quando a task estiver concluida e os checks
@@ -41,6 +43,7 @@ Se a entrega realmente tocar duas lanes de produto, quebre em tasks separadas.
   explicita.
 - Paths criticos sao governados por `.github/guardrails/path-policy.json`.
 - Em trabalho paralelo, contratos publicos seguem `additive-only` por default.
+- A task so e concluida depois de PR mergeada e issue fechada.
 
 ## Tipos de issue
 

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Helpers locais:
 powershell -ExecutionPolicy Bypass -File scripts/worktree_create.ps1 -Issue 27 -Slug exemplo-task -Lane ops-quality
 powershell -ExecutionPolicy Bypass -File scripts/worktree_status.ps1
 powershell -ExecutionPolicy Bypass -File scripts/worktree_remove.ps1 -Issue 27 -Slug exemplo-task -Lane ops-quality
+powershell -ExecutionPolicy Bypass -File scripts/pr_complete.ps1 -Pr 28
 ```
 
 Regras detalhadas:

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -63,6 +63,8 @@
   `.github/guardrails/path-policy.json`
 - Interfaces publicas ficam `additive-only` por default durante execucao
   simultanea
+- O fechamento da task passa a exigir checks verdes e merge confirmado; PR
+  aberta nao conta como concluido
 - `docs/STUDENT_PACK_PLAN.md` deixa de espelhar task-by-task e passa a apontar para milestone + epics + filtros de issues
 - `docs/AGENTS.md` permanece apenas como estado atual e historico de sessoes
 
@@ -90,6 +92,14 @@
 ---
 
 ## Sessoes Recentes
+
+### Sessao 36 - 2026-04-08 (fechamento por checks verdes e merge confirmado)
+- `scripts/pr_complete.ps1` passa a ser o helper recomendado para concluir uma
+  task com PR
+- A governanca passa a exigir checks verdes, merge confirmado, issue fechada e
+  branch remota removida quando aplicavel
+- Templates de task e PR deixam explicito que PR aberta nao significa task
+  concluida
 
 ### Sessao 35 - 2026-04-08 (fix no helper de remocao de worktree)
 - `scripts/worktree_remove.ps1` deixa de quebrar quando o merge-check local

--- a/docs/governance/parallel-lanes.md
+++ b/docs/governance/parallel-lanes.md
@@ -52,8 +52,10 @@ child tasks. Nao use uma task gigante multi-lane.
    - path `.claude/worktrees/<lane>/<issue-number>-<slug>/`
 4. Implementar somente dentro dessa worktree
 5. Abrir uma unica PR oficial para a task com `Closes #<issue-number>`
-6. Validar, atualizar a issue e fazer `squash merge`
-7. Remover a worktree da task
+6. Validar e atualizar a issue
+7. Concluir a PR com `scripts/pr_complete.ps1 -Pr <numero>` ou fluxo
+   equivalente
+8. Remover a worktree da task
 
 ## Handoff entre IAs ou humanos
 
@@ -100,6 +102,7 @@ Scripts oficiais:
 - `scripts/worktree_create.ps1`
 - `scripts/worktree_status.ps1`
 - `scripts/worktree_remove.ps1`
+- `scripts/pr_complete.ps1`
 
 Boas praticas:
 
@@ -107,6 +110,10 @@ Boas praticas:
 - abra uma segunda janela do editor para a worktree da task
 - nao reuse a mesma worktree para duas tasks diferentes
 - nao remova worktree com branch nao mergeada sem `-Force`
+- se o branch-base local estiver desatualizado, atualize o base ou use `-Force`;
+  o helper deve falhar com mensagem clara, nao com erro interno do PowerShell
+- nao considere a task concluida com a PR apenas aberta; confirme merge e issue
+  fechada
 - se o branch-base local estiver desatualizado, atualize o base ou use `-Force`;
   o helper deve falhar com mensagem clara, nao com erro interno do PowerShell
 

--- a/scripts/pr_complete.ps1
+++ b/scripts/pr_complete.ps1
@@ -1,0 +1,135 @@
+param(
+  [Parameter(Mandatory = $true)]
+  [int]$Pr,
+
+  [ValidateSet("squash", "merge", "rebase")]
+  [string]$Method = "squash",
+
+  [int]$PollSeconds = 10,
+
+  [int]$TimeoutSeconds = 1800,
+
+  [switch]$SkipRemoteDelete
+)
+
+$ErrorActionPreference = "Stop"
+
+function Get-PrData {
+  param([int]$Number)
+
+  $json = gh pr view $Number --json number,state,isDraft,url,headRefName,body
+  if (-not $json) {
+    throw "Nao foi possivel ler os dados da PR #$Number."
+  }
+
+  return $json | ConvertFrom-Json
+}
+
+function Get-LinkedIssues {
+  param([string]$Body)
+
+  $matches = [regex]::Matches($Body, '(?im)\bCloses\s+#(\d+)\b')
+  $issues = @()
+  foreach ($match in $matches) {
+    $issues += [int]$match.Groups[1].Value
+  }
+
+  return $issues | Sort-Object -Unique
+}
+
+function Confirm-IssuesClosed {
+  param([int[]]$IssueNumbers)
+
+  foreach ($issueNumber in $IssueNumbers) {
+    $issue = gh issue view $issueNumber --json state | ConvertFrom-Json
+    if ($issue.state -ne "CLOSED") {
+      throw "A issue #$issueNumber ainda nao fechou depois do merge da PR."
+    }
+  }
+}
+
+function Remove-RemoteBranchIfNeeded {
+  param([string]$BranchName)
+
+  if (-not $BranchName) {
+    return
+  }
+
+  $remoteBranch = git ls-remote --heads origin $BranchName
+  if (-not $remoteBranch) {
+    return
+  }
+
+  git push origin --delete $BranchName | Out-Null
+}
+
+$prData = Get-PrData -Number $Pr
+
+if ($prData.state -eq "MERGED") {
+  $linkedIssues = Get-LinkedIssues -Body $prData.body
+  if ($linkedIssues.Count -eq 0) {
+    throw "A PR #$Pr ja esta mergeada, mas nao foi encontrado nenhum 'Closes #<issue>' no corpo."
+  }
+
+  Confirm-IssuesClosed -IssueNumbers $linkedIssues
+
+  if (-not $SkipRemoteDelete) {
+    Remove-RemoteBranchIfNeeded -BranchName $prData.headRefName
+  }
+
+  Write-Output "PR #$Pr ja estava mergeada e a issue vinculada esta fechada."
+  exit 0
+}
+
+if ($prData.state -ne "OPEN") {
+  throw "A PR #$Pr esta em estado '$($prData.state)' e nao pode ser concluida."
+}
+
+if ($prData.isDraft) {
+  gh pr ready $Pr | Out-Null
+  $prData = Get-PrData -Number $Pr
+}
+
+$mergeArgs = @("pr", "merge", $Pr.ToString(), "--auto")
+switch ($Method) {
+  "squash" { $mergeArgs += "--squash" }
+  "merge" { $mergeArgs += "--merge" }
+  "rebase" { $mergeArgs += "--rebase" }
+}
+gh @mergeArgs | Out-Null
+
+gh pr checks $Pr --required --watch --fail-fast --interval $PollSeconds | Out-Null
+
+$deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+do {
+  $prData = Get-PrData -Number $Pr
+
+  if ($prData.state -eq "MERGED") {
+    break
+  }
+
+  if ($prData.state -ne "OPEN") {
+    throw "A PR #$Pr mudou para o estado '$($prData.state)' antes do merge."
+  }
+
+  Start-Sleep -Seconds $PollSeconds
+} while ((Get-Date) -lt $deadline)
+
+if ($prData.state -ne "MERGED") {
+  throw "A PR #$Pr nao apareceu como mergeada dentro do timeout de $TimeoutSeconds segundos."
+}
+
+$linkedIssues = Get-LinkedIssues -Body $prData.body
+if ($linkedIssues.Count -eq 0) {
+  throw "A PR #$Pr foi mergeada, mas nao foi encontrado nenhum 'Closes #<issue>' no corpo."
+}
+
+Confirm-IssuesClosed -IssueNumbers $linkedIssues
+
+if (-not $SkipRemoteDelete) {
+  Remove-RemoteBranchIfNeeded -BranchName $prData.headRefName
+}
+
+Write-Output "PR #$Pr mergeada com sucesso."
+Write-Output "Issues fechadas: $($linkedIssues -join ', ')"
+Write-Output "Branch remota tratada: $($prData.headRefName)"


### PR DESCRIPTION
## Issue

Closes #31

## Resumo

- endurece o contrato para que task so seja considerada concluida depois de checks verdes e merge confirmado
- adiciona o helper `scripts/pr_complete.ps1` para esperar checks, concluir o merge e verificar issue fechada
- atualiza templates e docs para explicitar que PR aberta nao conta como task entregue

## Paralelismo

- lane da task: `lane:ops-quality`
- worktree usada: `.claude/worktrees/ops-quality/31-complete-green-merge/`
- esta e a unica PR oficial da task: `sim`
- risco da task: `risk:shared`
- write-set principal: AGENTS.md, CLAUDE.md, CONTRIBUTING.md, .github/ISSUE_TEMPLATE/task.yml, .github/PULL_REQUEST_TEMPLATE.md, docs/AGENTS.md, docs/governance/parallel-lanes.md, scripts/pr_complete.ps1, README.md, COMO_RODAR.md
- coordenacao com outras tasks/PRs: toca governanca compartilhada e docs operacionais; sem conflito concorrente aberto no momento

## Compatibilidade

- politica aplicada: `n/a`
- impacto em API, schema ou docs publicos: nenhum contrato de aplicacao alterado; apenas governanca de fechamento e helper operacional de PR

## Validacao

- [x] validacoes executadas e registradas abaixo

```text
powershell -ExecutionPolicy Bypass -File scripts\pr_complete.ps1 -Pr 30
python - <<'PY'
from pathlib import Path
import yaml
for path in [
    Path('.github/ISSUE_TEMPLATE/task.yml'),
    Path('.github/workflows/pr-issue-guardrails.yml'),
    Path('.github/workflows/ci.yml'),
]:
    yaml.safe_load(path.read_text(encoding='utf-8'))
print('yaml ok')
PY
git diff --check
```

## Checklist

- [x] a branch segue `task/<issue-number>-<slug>`
- [ ] a issue vinculada esta atualizada com checklist/status/evidencias
- [x] a issue vinculada registra owner atual, lane oficial, workspace da task, write-set esperado e `risk:*`
- [x] docs relevantes foram atualizados quando necessario
- [x] lane da task e worktree oficial foram registradas nesta PR
- [x] se a task for `risk:shared` ou `risk:contract-sensitive`, a PR abriu em draft
- [ ] se a task for `risk:contract-sensitive`, a compatibilidade foi revisada e documentada
- [x] PR em draft apenas enquanto o trabalho ou as validacoes ainda estiverem incompletos
- [ ] checks obrigatorios verdes ou helper de conclusao acionado para aguardar
- [ ] pronto para `squash merge` em `master` quando os checks estiverem verdes
- [ ] nao considerar a task concluida ate confirmar merge, issue fechada e branch remota removida quando aplicavel
