### PR TITLE
[Task] Endurecer backend V2 para gate PostgreSQL e contrato HTTP

### DIFF
--- a/apps/api/app/dependencies.py
+++ b/apps/api/app/dependencies.py
@@ -98,7 +98,7 @@ def parse_years_csv(years: str | None) -> list[int]:
         seen.add(year)
         parsed.append(year)
 
-    return parsed
+    return sorted(parsed)
 
 
 def years_dependency(years: str | None = Query(default=None)) -> list[int]:

--- a/apps/api/tests/conftest.py
+++ b/apps/api/tests/conftest.py
@@ -1,14 +1,19 @@
 from __future__ import annotations
 
 import json
-import sqlite3
+import os
+from dataclasses import replace
 from pathlib import Path
 
 import pytest
 from fastapi.testclient import TestClient
+from sqlalchemy import text
 
 from apps.api.app.main import create_app
+from src.db import build_engine
 from src.settings import AppSettings, build_settings
+
+API_TEST_DATABASE_URL_ENV = "API_TEST_DATABASE_URL"
 
 
 def _write_active_universe_cache(settings: AppSettings) -> None:
@@ -36,157 +41,250 @@ def _write_canonical_accounts(settings: AppSettings) -> None:
     )
 
 
-def _seed_database(settings: AppSettings) -> None:
-    db_path = settings.paths.db_path
-    db_path.parent.mkdir(parents=True, exist_ok=True)
+def _drop_seed_tables(settings: AppSettings) -> None:
+    engine = build_engine(settings)
+    with engine.begin() as conn:
+        conn.execute(text("DROP TABLE IF EXISTS company_refresh_status"))
+        conn.execute(text("DROP TABLE IF EXISTS financial_reports"))
+        conn.execute(text("DROP TABLE IF EXISTS companies"))
 
-    rows = [
-        ("PETROBRAS", 9512, "BPA", 2023, "2023", "bpa-1", "1", "Ativo Total", "Ativo Total", 0, 1000.0),
-        ("PETROBRAS", 9512, "BPA", 2023, "2023", "bpa-2", "1.01", "Ativo Circulante", "Ativo Circulante", 0, 400.0),
-        ("PETROBRAS", 9512, "BPA", 2023, "2023", "bpa-3", "1.01.01", "Caixa", "Caixa", 0, 100.0),
-        ("PETROBRAS", 9512, "BPP", 2023, "2023", "bpp-1", "2", "Passivo Total", "Passivo Total", 0, 700.0),
-        ("PETROBRAS", 9512, "BPP", 2023, "2023", "bpp-2", "2.01", "Passivo Circulante", "Passivo Circulante", 0, 250.0),
-        ("PETROBRAS", 9512, "BPP", 2023, "2023", "bpp-3", "2.02", "Passivo Nao Circulante", "Passivo Nao Circulante", 0, 300.0),
-        ("PETROBRAS", 9512, "BPP", 2023, "2023", "bpp-4", "2.03", "Patrimonio Liquido", "Patrimonio Liquido", 0, 300.0),
-        ("PETROBRAS", 9512, "DRE", 2023, "2023", "dre-1", "3.01", "Receita Liquida", "Receita", 0, 1000.0),
-        ("PETROBRAS", 9512, "DRE", 2023, "2023", "dre-2", "3.03", "Resultado Bruto", "Res_Bruto", 0, 400.0),
-        ("PETROBRAS", 9512, "DRE", 2023, "2023", "dre-3", "3.05", "EBIT", "EBIT", 0, 200.0),
-        ("PETROBRAS", 9512, "DRE", 2023, "2023", "dre-4", "3.11", "Lucro Liquido", "Lucro_Liq", 0, 150.0),
-        ("PETROBRAS", 9512, "DFC", 2023, "2023", "dfc-1", "6.01", "Fluxo Operacional", "FCO", 0, 220.0),
-        ("PETROBRAS", 9512, "DFC", 2023, "2023", "dfc-2", "6.01.01.01", "Depreciacao e amortizacao", "D&A", 0, 20.0),
-        ("PETROBRAS", 9512, "DFC", 2023, "2023", "dfc-3", "6.02", "Fluxo de Investimento", "FCI", 0, -80.0),
-        ("PETROBRAS", 9512, "DFC", 2023, "2023", "dfc-4", "6.03", "Fluxo de Financiamento", "FCF", 0, -30.0),
-        ("PETROBRAS", 9512, "BPA", 2024, "2024", "bpa-4", "1", "Ativo Total", "Ativo Total", 0, 1200.0),
-        ("PETROBRAS", 9512, "BPA", 2024, "2024", "bpa-5", "1.01", "Ativo Circulante", "Ativo Circulante", 0, 500.0),
-        ("PETROBRAS", 9512, "BPA", 2024, "2024", "bpa-6", "1.01.01", "Caixa", "Caixa", 0, 120.0),
-        ("PETROBRAS", 9512, "BPP", 2024, "2024", "bpp-5", "2", "Passivo Total", "Passivo Total", 0, 820.0),
-        ("PETROBRAS", 9512, "BPP", 2024, "2024", "bpp-6", "2.01", "Passivo Circulante", "Passivo Circulante", 0, 280.0),
-        ("PETROBRAS", 9512, "BPP", 2024, "2024", "bpp-7", "2.02", "Passivo Nao Circulante", "Passivo Nao Circulante", 0, 340.0),
-        ("PETROBRAS", 9512, "BPP", 2024, "2024", "bpp-8", "2.03", "Patrimonio Liquido", "Patrimonio Liquido", 0, 380.0),
-        ("PETROBRAS", 9512, "DRE", 2024, "2024", "dre-5", "3.01", "Receita Liquida", "Receita", 0, 1100.0),
-        ("PETROBRAS", 9512, "DRE", 2024, "2024", "dre-6", "3.03", "Resultado Bruto", "Res_Bruto", 0, 450.0),
-        ("PETROBRAS", 9512, "DRE", 2024, "2024", "dre-7", "3.05", "EBIT", "EBIT", 0, 240.0),
-        ("PETROBRAS", 9512, "DRE", 2024, "2024", "dre-8", "3.11", "Lucro Liquido", "Lucro_Liq", 0, 180.0),
-        ("PETROBRAS", 9512, "DFC", 2024, "2024", "dfc-5", "6.01", "Fluxo Operacional", "FCO", 0, 250.0),
-        ("PETROBRAS", 9512, "DFC", 2024, "2024", "dfc-6", "6.01.01.01", "Depreciacao e amortizacao", "D&A", 0, 25.0),
-        ("PETROBRAS", 9512, "DFC", 2024, "2024", "dfc-7", "6.02", "Fluxo de Investimento", "FCI", 0, -95.0),
-        ("PETROBRAS", 9512, "DFC", 2024, "2024", "dfc-8", "6.03", "Fluxo de Financiamento", "FCF", 0, -50.0),
-        ("VALE", 4170, "BPA", 2024, "2024", "vale-bpa", "1", "Ativo Total", "Ativo Total", 0, 900.0),
-        ("VALE", 4170, "BPP", 2024, "2024", "vale-bpp", "2", "Passivo Total", "Passivo Total", 0, 500.0),
-        ("VALE", 4170, "DRE", 2024, "2024", "vale-dre", "3.01", "Receita Liquida", "Receita", 0, 800.0),
-        ("VALE", 4170, "DFC", 2024, "2024", "vale-dfc", "6.01", "Fluxo Operacional", "FCO", 0, 180.0),
-        ("SABESP", 11223, "BPA", 2024, "2024", "sabesp-bpa", "1", "Ativo Total", "Ativo Total", 0, 650.0),
-        ("SABESP", 11223, "BPP", 2024, "2024", "sabesp-bpp", "2", "Passivo Total", "Passivo Total", 0, 320.0),
-        ("SABESP", 11223, "DRE", 2024, "2024", "sabesp-dre", "3.01", "Receita Liquida", "Receita", 0, 420.0),
-        ("SABESP", 11223, "DFC", 2024, "2024", "sabesp-dfc", "6.01", "Fluxo Operacional", "FCO", 0, 90.0),
+
+def _reset_seed_database(settings: AppSettings) -> None:
+    if not settings.database_url:
+        if settings.paths.db_path.exists():
+            settings.paths.db_path.unlink(missing_ok=True)
+        return
+    _drop_seed_tables(settings)
+
+
+def _seed_database(settings: AppSettings) -> None:
+    if not settings.database_url:
+        settings.paths.db_path.parent.mkdir(parents=True, exist_ok=True)
+
+    _reset_seed_database(settings)
+    engine = build_engine(settings)
+
+    company_rows = [
+        {
+            "cd_cvm": 9512,
+            "company_name": "PETROBRAS",
+            "nome_comercial": "Petrobras",
+            "cnpj": "33.000.167/0001-01",
+            "setor_cvm": "Energia",
+            "setor_analitico": "Energia",
+            "company_type": "comercial",
+            "ticker_b3": "PETR4",
+            "is_active": 1,
+            "updated_at": "2026-04-08T09:00:00",
+        },
+        {
+            "cd_cvm": 4170,
+            "company_name": "VALE",
+            "nome_comercial": "Vale",
+            "cnpj": "33.592.510/0001-54",
+            "setor_cvm": "Mineracao",
+            "setor_analitico": "Materiais Basicos",
+            "company_type": "comercial",
+            "ticker_b3": "VALE3",
+            "is_active": 1,
+            "updated_at": "2026-04-08T09:00:00",
+        },
+        {
+            "cd_cvm": 11223,
+            "company_name": "SABESP",
+            "nome_comercial": "Sabesp",
+            "cnpj": "43.776.517/0001-80",
+            "setor_cvm": "Saneamento",
+            "setor_analitico": None,
+            "company_type": "comercial",
+            "ticker_b3": "SBSP3",
+            "is_active": 1,
+            "updated_at": "2026-04-08T09:00:00",
+        },
+        {
+            "cd_cvm": 77889,
+            "company_name": "SEM DADOS",
+            "nome_comercial": "Sem Dados",
+            "cnpj": "00.000.000/0001-00",
+            "setor_cvm": "Financeiro",
+            "setor_analitico": "Financeiro",
+            "company_type": "comercial",
+            "ticker_b3": "SEMD3",
+            "is_active": 1,
+            "updated_at": "2026-04-08T09:00:00",
+        },
+    ]
+    financial_rows = [
+        {"COMPANY_NAME": "PETROBRAS", "CD_CVM": 9512, "STATEMENT_TYPE": "BPA", "REPORT_YEAR": 2023, "PERIOD_LABEL": "2023", "LINE_ID_BASE": "bpa-1", "CD_CONTA": "1", "DS_CONTA": "Ativo Total", "STANDARD_NAME": "Ativo Total", "QA_CONFLICT": 0, "VL_CONTA": 1000.0},
+        {"COMPANY_NAME": "PETROBRAS", "CD_CVM": 9512, "STATEMENT_TYPE": "BPA", "REPORT_YEAR": 2023, "PERIOD_LABEL": "2023", "LINE_ID_BASE": "bpa-2", "CD_CONTA": "1.01", "DS_CONTA": "Ativo Circulante", "STANDARD_NAME": "Ativo Circulante", "QA_CONFLICT": 0, "VL_CONTA": 400.0},
+        {"COMPANY_NAME": "PETROBRAS", "CD_CVM": 9512, "STATEMENT_TYPE": "BPA", "REPORT_YEAR": 2023, "PERIOD_LABEL": "2023", "LINE_ID_BASE": "bpa-3", "CD_CONTA": "1.01.01", "DS_CONTA": "Caixa", "STANDARD_NAME": "Caixa", "QA_CONFLICT": 0, "VL_CONTA": 100.0},
+        {"COMPANY_NAME": "PETROBRAS", "CD_CVM": 9512, "STATEMENT_TYPE": "BPP", "REPORT_YEAR": 2023, "PERIOD_LABEL": "2023", "LINE_ID_BASE": "bpp-1", "CD_CONTA": "2", "DS_CONTA": "Passivo Total", "STANDARD_NAME": "Passivo Total", "QA_CONFLICT": 0, "VL_CONTA": 700.0},
+        {"COMPANY_NAME": "PETROBRAS", "CD_CVM": 9512, "STATEMENT_TYPE": "BPP", "REPORT_YEAR": 2023, "PERIOD_LABEL": "2023", "LINE_ID_BASE": "bpp-2", "CD_CONTA": "2.01", "DS_CONTA": "Passivo Circulante", "STANDARD_NAME": "Passivo Circulante", "QA_CONFLICT": 0, "VL_CONTA": 250.0},
+        {"COMPANY_NAME": "PETROBRAS", "CD_CVM": 9512, "STATEMENT_TYPE": "BPP", "REPORT_YEAR": 2023, "PERIOD_LABEL": "2023", "LINE_ID_BASE": "bpp-3", "CD_CONTA": "2.02", "DS_CONTA": "Passivo Nao Circulante", "STANDARD_NAME": "Passivo Nao Circulante", "QA_CONFLICT": 0, "VL_CONTA": 300.0},
+        {"COMPANY_NAME": "PETROBRAS", "CD_CVM": 9512, "STATEMENT_TYPE": "BPP", "REPORT_YEAR": 2023, "PERIOD_LABEL": "2023", "LINE_ID_BASE": "bpp-4", "CD_CONTA": "2.03", "DS_CONTA": "Patrimonio Liquido", "STANDARD_NAME": "Patrimonio Liquido", "QA_CONFLICT": 0, "VL_CONTA": 300.0},
+        {"COMPANY_NAME": "PETROBRAS", "CD_CVM": 9512, "STATEMENT_TYPE": "DRE", "REPORT_YEAR": 2023, "PERIOD_LABEL": "2023", "LINE_ID_BASE": "dre-1", "CD_CONTA": "3.01", "DS_CONTA": "Receita Liquida", "STANDARD_NAME": "Receita", "QA_CONFLICT": 0, "VL_CONTA": 1000.0},
+        {"COMPANY_NAME": "PETROBRAS", "CD_CVM": 9512, "STATEMENT_TYPE": "DRE", "REPORT_YEAR": 2023, "PERIOD_LABEL": "2023", "LINE_ID_BASE": "dre-2", "CD_CONTA": "3.03", "DS_CONTA": "Resultado Bruto", "STANDARD_NAME": "Res_Bruto", "QA_CONFLICT": 0, "VL_CONTA": 400.0},
+        {"COMPANY_NAME": "PETROBRAS", "CD_CVM": 9512, "STATEMENT_TYPE": "DRE", "REPORT_YEAR": 2023, "PERIOD_LABEL": "2023", "LINE_ID_BASE": "dre-3", "CD_CONTA": "3.05", "DS_CONTA": "EBIT", "STANDARD_NAME": "EBIT", "QA_CONFLICT": 0, "VL_CONTA": 200.0},
+        {"COMPANY_NAME": "PETROBRAS", "CD_CVM": 9512, "STATEMENT_TYPE": "DRE", "REPORT_YEAR": 2023, "PERIOD_LABEL": "2023", "LINE_ID_BASE": "dre-4", "CD_CONTA": "3.11", "DS_CONTA": "Lucro Liquido", "STANDARD_NAME": "Lucro_Liq", "QA_CONFLICT": 0, "VL_CONTA": 150.0},
+        {"COMPANY_NAME": "PETROBRAS", "CD_CVM": 9512, "STATEMENT_TYPE": "DFC", "REPORT_YEAR": 2023, "PERIOD_LABEL": "2023", "LINE_ID_BASE": "dfc-1", "CD_CONTA": "6.01", "DS_CONTA": "Fluxo Operacional", "STANDARD_NAME": "FCO", "QA_CONFLICT": 0, "VL_CONTA": 220.0},
+        {"COMPANY_NAME": "PETROBRAS", "CD_CVM": 9512, "STATEMENT_TYPE": "DFC", "REPORT_YEAR": 2023, "PERIOD_LABEL": "2023", "LINE_ID_BASE": "dfc-2", "CD_CONTA": "6.01.01.01", "DS_CONTA": "Depreciacao e amortizacao", "STANDARD_NAME": "D&A", "QA_CONFLICT": 0, "VL_CONTA": 20.0},
+        {"COMPANY_NAME": "PETROBRAS", "CD_CVM": 9512, "STATEMENT_TYPE": "DFC", "REPORT_YEAR": 2023, "PERIOD_LABEL": "2023", "LINE_ID_BASE": "dfc-3", "CD_CONTA": "6.02", "DS_CONTA": "Fluxo de Investimento", "STANDARD_NAME": "FCI", "QA_CONFLICT": 0, "VL_CONTA": -80.0},
+        {"COMPANY_NAME": "PETROBRAS", "CD_CVM": 9512, "STATEMENT_TYPE": "DFC", "REPORT_YEAR": 2023, "PERIOD_LABEL": "2023", "LINE_ID_BASE": "dfc-4", "CD_CONTA": "6.03", "DS_CONTA": "Fluxo de Financiamento", "STANDARD_NAME": "FCF", "QA_CONFLICT": 0, "VL_CONTA": -30.0},
+        {"COMPANY_NAME": "PETROBRAS", "CD_CVM": 9512, "STATEMENT_TYPE": "BPA", "REPORT_YEAR": 2024, "PERIOD_LABEL": "2024", "LINE_ID_BASE": "bpa-4", "CD_CONTA": "1", "DS_CONTA": "Ativo Total", "STANDARD_NAME": "Ativo Total", "QA_CONFLICT": 0, "VL_CONTA": 1200.0},
+        {"COMPANY_NAME": "PETROBRAS", "CD_CVM": 9512, "STATEMENT_TYPE": "BPA", "REPORT_YEAR": 2024, "PERIOD_LABEL": "2024", "LINE_ID_BASE": "bpa-5", "CD_CONTA": "1.01", "DS_CONTA": "Ativo Circulante", "STANDARD_NAME": "Ativo Circulante", "QA_CONFLICT": 0, "VL_CONTA": 500.0},
+        {"COMPANY_NAME": "PETROBRAS", "CD_CVM": 9512, "STATEMENT_TYPE": "BPA", "REPORT_YEAR": 2024, "PERIOD_LABEL": "2024", "LINE_ID_BASE": "bpa-6", "CD_CONTA": "1.01.01", "DS_CONTA": "Caixa", "STANDARD_NAME": "Caixa", "QA_CONFLICT": 0, "VL_CONTA": 120.0},
+        {"COMPANY_NAME": "PETROBRAS", "CD_CVM": 9512, "STATEMENT_TYPE": "BPP", "REPORT_YEAR": 2024, "PERIOD_LABEL": "2024", "LINE_ID_BASE": "bpp-5", "CD_CONTA": "2", "DS_CONTA": "Passivo Total", "STANDARD_NAME": "Passivo Total", "QA_CONFLICT": 0, "VL_CONTA": 820.0},
+        {"COMPANY_NAME": "PETROBRAS", "CD_CVM": 9512, "STATEMENT_TYPE": "BPP", "REPORT_YEAR": 2024, "PERIOD_LABEL": "2024", "LINE_ID_BASE": "bpp-6", "CD_CONTA": "2.01", "DS_CONTA": "Passivo Circulante", "STANDARD_NAME": "Passivo Circulante", "QA_CONFLICT": 0, "VL_CONTA": 280.0},
+        {"COMPANY_NAME": "PETROBRAS", "CD_CVM": 9512, "STATEMENT_TYPE": "BPP", "REPORT_YEAR": 2024, "PERIOD_LABEL": "2024", "LINE_ID_BASE": "bpp-7", "CD_CONTA": "2.02", "DS_CONTA": "Passivo Nao Circulante", "STANDARD_NAME": "Passivo Nao Circulante", "QA_CONFLICT": 0, "VL_CONTA": 340.0},
+        {"COMPANY_NAME": "PETROBRAS", "CD_CVM": 9512, "STATEMENT_TYPE": "BPP", "REPORT_YEAR": 2024, "PERIOD_LABEL": "2024", "LINE_ID_BASE": "bpp-8", "CD_CONTA": "2.03", "DS_CONTA": "Patrimonio Liquido", "STANDARD_NAME": "Patrimonio Liquido", "QA_CONFLICT": 0, "VL_CONTA": 380.0},
+        {"COMPANY_NAME": "PETROBRAS", "CD_CVM": 9512, "STATEMENT_TYPE": "DRE", "REPORT_YEAR": 2024, "PERIOD_LABEL": "2024", "LINE_ID_BASE": "dre-5", "CD_CONTA": "3.01", "DS_CONTA": "Receita Liquida", "STANDARD_NAME": "Receita", "QA_CONFLICT": 0, "VL_CONTA": 1100.0},
+        {"COMPANY_NAME": "PETROBRAS", "CD_CVM": 9512, "STATEMENT_TYPE": "DRE", "REPORT_YEAR": 2024, "PERIOD_LABEL": "2024", "LINE_ID_BASE": "dre-6", "CD_CONTA": "3.03", "DS_CONTA": "Resultado Bruto", "STANDARD_NAME": "Res_Bruto", "QA_CONFLICT": 0, "VL_CONTA": 450.0},
+        {"COMPANY_NAME": "PETROBRAS", "CD_CVM": 9512, "STATEMENT_TYPE": "DRE", "REPORT_YEAR": 2024, "PERIOD_LABEL": "2024", "LINE_ID_BASE": "dre-7", "CD_CONTA": "3.05", "DS_CONTA": "EBIT", "STANDARD_NAME": "EBIT", "QA_CONFLICT": 0, "VL_CONTA": 240.0},
+        {"COMPANY_NAME": "PETROBRAS", "CD_CVM": 9512, "STATEMENT_TYPE": "DRE", "REPORT_YEAR": 2024, "PERIOD_LABEL": "2024", "LINE_ID_BASE": "dre-8", "CD_CONTA": "3.11", "DS_CONTA": "Lucro Liquido", "STANDARD_NAME": "Lucro_Liq", "QA_CONFLICT": 0, "VL_CONTA": 180.0},
+        {"COMPANY_NAME": "PETROBRAS", "CD_CVM": 9512, "STATEMENT_TYPE": "DFC", "REPORT_YEAR": 2024, "PERIOD_LABEL": "2024", "LINE_ID_BASE": "dfc-5", "CD_CONTA": "6.01", "DS_CONTA": "Fluxo Operacional", "STANDARD_NAME": "FCO", "QA_CONFLICT": 0, "VL_CONTA": 250.0},
+        {"COMPANY_NAME": "PETROBRAS", "CD_CVM": 9512, "STATEMENT_TYPE": "DFC", "REPORT_YEAR": 2024, "PERIOD_LABEL": "2024", "LINE_ID_BASE": "dfc-6", "CD_CONTA": "6.01.01.01", "DS_CONTA": "Depreciacao e amortizacao", "STANDARD_NAME": "D&A", "QA_CONFLICT": 0, "VL_CONTA": 25.0},
+        {"COMPANY_NAME": "PETROBRAS", "CD_CVM": 9512, "STATEMENT_TYPE": "DFC", "REPORT_YEAR": 2024, "PERIOD_LABEL": "2024", "LINE_ID_BASE": "dfc-7", "CD_CONTA": "6.02", "DS_CONTA": "Fluxo de Investimento", "STANDARD_NAME": "FCI", "QA_CONFLICT": 0, "VL_CONTA": -95.0},
+        {"COMPANY_NAME": "PETROBRAS", "CD_CVM": 9512, "STATEMENT_TYPE": "DFC", "REPORT_YEAR": 2024, "PERIOD_LABEL": "2024", "LINE_ID_BASE": "dfc-8", "CD_CONTA": "6.03", "DS_CONTA": "Fluxo de Financiamento", "STANDARD_NAME": "FCF", "QA_CONFLICT": 0, "VL_CONTA": -50.0},
+        {"COMPANY_NAME": "VALE", "CD_CVM": 4170, "STATEMENT_TYPE": "BPA", "REPORT_YEAR": 2024, "PERIOD_LABEL": "2024", "LINE_ID_BASE": "vale-bpa", "CD_CONTA": "1", "DS_CONTA": "Ativo Total", "STANDARD_NAME": "Ativo Total", "QA_CONFLICT": 0, "VL_CONTA": 900.0},
+        {"COMPANY_NAME": "VALE", "CD_CVM": 4170, "STATEMENT_TYPE": "BPP", "REPORT_YEAR": 2024, "PERIOD_LABEL": "2024", "LINE_ID_BASE": "vale-bpp", "CD_CONTA": "2", "DS_CONTA": "Passivo Total", "STANDARD_NAME": "Passivo Total", "QA_CONFLICT": 0, "VL_CONTA": 500.0},
+        {"COMPANY_NAME": "VALE", "CD_CVM": 4170, "STATEMENT_TYPE": "DRE", "REPORT_YEAR": 2024, "PERIOD_LABEL": "2024", "LINE_ID_BASE": "vale-dre", "CD_CONTA": "3.01", "DS_CONTA": "Receita Liquida", "STANDARD_NAME": "Receita", "QA_CONFLICT": 0, "VL_CONTA": 800.0},
+        {"COMPANY_NAME": "VALE", "CD_CVM": 4170, "STATEMENT_TYPE": "DFC", "REPORT_YEAR": 2024, "PERIOD_LABEL": "2024", "LINE_ID_BASE": "vale-dfc", "CD_CONTA": "6.01", "DS_CONTA": "Fluxo Operacional", "STANDARD_NAME": "FCO", "QA_CONFLICT": 0, "VL_CONTA": 180.0},
+        {"COMPANY_NAME": "SABESP", "CD_CVM": 11223, "STATEMENT_TYPE": "BPA", "REPORT_YEAR": 2024, "PERIOD_LABEL": "2024", "LINE_ID_BASE": "sabesp-bpa", "CD_CONTA": "1", "DS_CONTA": "Ativo Total", "STANDARD_NAME": "Ativo Total", "QA_CONFLICT": 0, "VL_CONTA": 650.0},
+        {"COMPANY_NAME": "SABESP", "CD_CVM": 11223, "STATEMENT_TYPE": "BPP", "REPORT_YEAR": 2024, "PERIOD_LABEL": "2024", "LINE_ID_BASE": "sabesp-bpp", "CD_CONTA": "2", "DS_CONTA": "Passivo Total", "STANDARD_NAME": "Passivo Total", "QA_CONFLICT": 0, "VL_CONTA": 320.0},
+        {"COMPANY_NAME": "SABESP", "CD_CVM": 11223, "STATEMENT_TYPE": "DRE", "REPORT_YEAR": 2024, "PERIOD_LABEL": "2024", "LINE_ID_BASE": "sabesp-dre", "CD_CONTA": "3.01", "DS_CONTA": "Receita Liquida", "STANDARD_NAME": "Receita", "QA_CONFLICT": 0, "VL_CONTA": 420.0},
+        {"COMPANY_NAME": "SABESP", "CD_CVM": 11223, "STATEMENT_TYPE": "DFC", "REPORT_YEAR": 2024, "PERIOD_LABEL": "2024", "LINE_ID_BASE": "sabesp-dfc", "CD_CONTA": "6.01", "DS_CONTA": "Fluxo Operacional", "STANDARD_NAME": "FCO", "QA_CONFLICT": 0, "VL_CONTA": 90.0},
     ]
 
-    with sqlite3.connect(str(db_path)) as conn:
+    with engine.begin() as conn:
         conn.execute(
-            """
-            CREATE TABLE companies (
-                cd_cvm INTEGER PRIMARY KEY,
-                company_name TEXT NOT NULL,
-                nome_comercial TEXT,
-                cnpj TEXT,
-                setor_cvm TEXT,
-                setor_analitico TEXT,
-                company_type TEXT,
-                ticker_b3 TEXT,
-                is_active INTEGER,
-                updated_at TEXT
+            text(
+                """
+                CREATE TABLE companies (
+                    cd_cvm INTEGER PRIMARY KEY,
+                    company_name TEXT NOT NULL,
+                    nome_comercial TEXT,
+                    cnpj TEXT,
+                    setor_cvm TEXT,
+                    setor_analitico TEXT,
+                    company_type TEXT,
+                    ticker_b3 TEXT,
+                    is_active INTEGER,
+                    updated_at TEXT
+                )
+                """
             )
-            """
         )
         conn.execute(
-            """
-            CREATE TABLE financial_reports (
-                COMPANY_NAME TEXT,
-                CD_CVM INTEGER,
-                STATEMENT_TYPE TEXT,
-                REPORT_YEAR INTEGER,
-                PERIOD_LABEL TEXT,
-                LINE_ID_BASE TEXT,
-                CD_CONTA TEXT,
-                DS_CONTA TEXT,
-                STANDARD_NAME TEXT,
-                QA_CONFLICT INTEGER,
-                VL_CONTA REAL
+            text(
+                """
+                CREATE TABLE financial_reports (
+                    COMPANY_NAME TEXT,
+                    CD_CVM INTEGER,
+                    STATEMENT_TYPE TEXT,
+                    REPORT_YEAR INTEGER,
+                    PERIOD_LABEL TEXT,
+                    LINE_ID_BASE TEXT,
+                    CD_CONTA TEXT,
+                    DS_CONTA TEXT,
+                    STANDARD_NAME TEXT,
+                    QA_CONFLICT INTEGER,
+                    VL_CONTA REAL
+                )
+                """
             )
-            """
         )
         conn.execute(
-            """
-            CREATE TABLE company_refresh_status (
-                cd_cvm INTEGER PRIMARY KEY,
-                company_name TEXT,
-                source_scope TEXT,
-                last_attempt_at TEXT,
-                last_success_at TEXT,
-                last_status TEXT,
-                last_error TEXT,
-                last_start_year INTEGER,
-                last_end_year INTEGER,
-                last_rows_inserted INTEGER,
-                updated_at TEXT
+            text(
+                """
+                CREATE TABLE company_refresh_status (
+                    cd_cvm INTEGER PRIMARY KEY,
+                    company_name TEXT,
+                    source_scope TEXT,
+                    last_attempt_at TEXT,
+                    last_success_at TEXT,
+                    last_status TEXT,
+                    last_error TEXT,
+                    last_start_year INTEGER,
+                    last_end_year INTEGER,
+                    last_rows_inserted INTEGER,
+                    updated_at TEXT
+                )
+                """
             )
-            """
         )
-        conn.executemany(
-            """
-            INSERT INTO companies (
-                cd_cvm, company_name, nome_comercial, cnpj,
-                setor_cvm, setor_analitico, company_type, ticker_b3, is_active, updated_at
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            """,
+        conn.execute(
+            text(
+                """
+                INSERT INTO companies (
+                    cd_cvm, company_name, nome_comercial, cnpj,
+                    setor_cvm, setor_analitico, company_type, ticker_b3, is_active, updated_at
+                ) VALUES (
+                    :cd_cvm, :company_name, :nome_comercial, :cnpj,
+                    :setor_cvm, :setor_analitico, :company_type, :ticker_b3, :is_active, :updated_at
+                )
+                """
+            ),
+            company_rows,
+        )
+        conn.execute(
+            text(
+                """
+                INSERT INTO financial_reports (
+                    COMPANY_NAME, CD_CVM, STATEMENT_TYPE, REPORT_YEAR, PERIOD_LABEL,
+                    LINE_ID_BASE, CD_CONTA, DS_CONTA, STANDARD_NAME, QA_CONFLICT, VL_CONTA
+                ) VALUES (
+                    :COMPANY_NAME, :CD_CVM, :STATEMENT_TYPE, :REPORT_YEAR, :PERIOD_LABEL,
+                    :LINE_ID_BASE, :CD_CONTA, :DS_CONTA, :STANDARD_NAME, :QA_CONFLICT, :VL_CONTA
+                )
+                """
+            ),
+            financial_rows,
+        )
+        conn.execute(
+            text(
+                """
+                INSERT INTO company_refresh_status (
+                    cd_cvm, company_name, source_scope, last_attempt_at, last_success_at,
+                    last_status, last_error, last_start_year, last_end_year,
+                    last_rows_inserted, updated_at
+                ) VALUES (
+                    :cd_cvm, :company_name, :source_scope, :last_attempt_at, :last_success_at,
+                    :last_status, :last_error, :last_start_year, :last_end_year,
+                    :last_rows_inserted, :updated_at
+                )
+                """
+            ),
             [
-                (9512, "PETROBRAS", "Petrobras", "33.000.167/0001-01", "Energia", "Energia", "comercial", "PETR4", 1, "2026-04-08T09:00:00"),
-                (4170, "VALE", "Vale", "33.592.510/0001-54", "Mineracao", "Materiais Basicos", "comercial", "VALE3", 1, "2026-04-08T09:00:00"),
-                (11223, "SABESP", "Sabesp", "43.776.517/0001-80", "Saneamento", None, "comercial", "SBSP3", 1, "2026-04-08T09:00:00"),
-                (77889, "SEM DADOS", "Sem Dados", "00.000.000/0001-00", "Financeiro", "Financeiro", "comercial", "SEMD3", 1, "2026-04-08T09:00:00"),
+                {
+                    "cd_cvm": 9512,
+                    "company_name": "PETROBRAS",
+                    "source_scope": "local",
+                    "last_attempt_at": "2026-04-08T08:50:00",
+                    "last_success_at": "2026-04-08T08:55:00",
+                    "last_status": "success",
+                    "last_error": None,
+                    "last_start_year": 2023,
+                    "last_end_year": 2024,
+                    "last_rows_inserted": 30,
+                    "updated_at": "2026-04-08T08:55:00",
+                }
             ],
         )
-        conn.executemany(
-            """
-            INSERT INTO financial_reports (
-                COMPANY_NAME, CD_CVM, STATEMENT_TYPE, REPORT_YEAR, PERIOD_LABEL,
-                LINE_ID_BASE, CD_CONTA, DS_CONTA, STANDARD_NAME, QA_CONFLICT, VL_CONTA
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            """,
-            rows,
-        )
-        conn.execute(
-            """
-            INSERT INTO company_refresh_status (
-                cd_cvm, company_name, source_scope, last_attempt_at, last_success_at,
-                last_status, last_error, last_start_year, last_end_year,
-                last_rows_inserted, updated_at
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            """,
-            (
-                9512,
-                "PETROBRAS",
-                "local",
-                "2026-04-08T08:50:00",
-                "2026-04-08T08:55:00",
-                "success",
-                None,
-                2023,
-                2024,
-                30,
-                "2026-04-08T08:55:00",
-            ),
-        )
-        conn.commit()
 
 
 @pytest.fixture
 def api_settings(tmp_path: Path) -> AppSettings:
     settings = build_settings(project_root=tmp_path)
+    explicit_database_url = os.getenv(API_TEST_DATABASE_URL_ENV)
+    if explicit_database_url:
+        settings = replace(settings, database_url=explicit_database_url)
+
     _write_canonical_accounts(settings)
     _write_active_universe_cache(settings)
     _seed_database(settings)
-    return settings
+    yield settings
+    if settings.database_url:
+        _drop_seed_tables(settings)
 
 
 @pytest.fixture

--- a/apps/api/tests/test_api_contract.py
+++ b/apps/api/tests/test_api_contract.py
@@ -15,7 +15,7 @@ def test_health_returns_ok_payload(client: TestClient):
     payload = response.json()
     assert payload["status"] == "ok"
     assert payload["version"] == "v2-phase1"
-    assert payload["database_dialect"] == "sqlite"
+    assert payload["database_dialect"] == client.app.state.read_service.engine.dialect.name
     assert payload["required_tables"] == ["financial_reports", "companies"]
 
 
@@ -73,6 +73,23 @@ def test_companies_sector_filter_uses_canonical_slug(client: TestClient):
     assert payload["items"][0]["sector_name"] == "Saneamento"
 
 
+def test_companies_unknown_sector_returns_empty_page_with_stable_payload(client: TestClient):
+    response = client.get("/companies", params={"sector": "setor-inexistente"})
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["items"] == []
+    assert payload["pagination"] == {
+        "page": 1,
+        "page_size": 20,
+        "total_items": 0,
+        "total_pages": 1,
+        "has_next": False,
+        "has_previous": False,
+    }
+    assert payload["applied_filters"] == {"search": "", "sector": "setor-inexistente"}
+
+
 def test_companies_filters_returns_canonical_sector_options(client: TestClient):
     response = client.get("/companies/filters")
 
@@ -120,6 +137,13 @@ def test_company_years_returns_sorted_values(client: TestClient):
     assert response.json() == [2023, 2024]
 
 
+def test_company_years_returns_empty_list_when_company_has_no_reports(client: TestClient):
+    response = client.get("/companies/77889/years")
+
+    assert response.status_code == 200
+    assert response.json() == []
+
+
 def test_company_statement_returns_matrix(client: TestClient):
     response = client.get(
         "/companies/9512/statements",
@@ -132,6 +156,30 @@ def test_company_statement_returns_matrix(client: TestClient):
     assert payload["years"] == [2023, 2024]
     assert "2023" in payload["table"]["columns"]
     assert "2024" in payload["table"]["columns"]
+
+
+def test_company_statement_sorts_requested_years_for_stable_contract(client: TestClient):
+    response = client.get(
+        "/companies/9512/statements",
+        params={"stmt": "DRE", "years": "2024,2023"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["years"] == [2023, 2024]
+    assert payload["table"]["columns"][-2:] == ["2023", "2024"]
+
+
+def test_company_statement_returns_empty_table_for_year_without_data(client: TestClient):
+    response = client.get(
+        "/companies/4170/statements",
+        params={"stmt": "DRE", "years": "2023"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["years"] == [2023]
+    assert payload["table"] == {"columns": [], "rows": []}
 
 
 def test_company_statement_rejects_invalid_years(client: TestClient):
@@ -173,6 +221,26 @@ def test_company_kpis_returns_annual_and_quarterly_tables(client: TestClient):
     assert payload["years"] == [2023, 2024]
     assert payload["annual"]["rows"]
     assert payload["quarterly"]["rows"]
+
+
+def test_company_kpis_sort_requested_years_for_stable_contract(client: TestClient):
+    response = client.get("/companies/9512/kpis", params={"years": "2024,2023"})
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["years"] == [2023, 2024]
+    assert "2023" in payload["annual"]["columns"]
+    assert "2024" in payload["annual"]["columns"]
+
+
+def test_company_kpis_return_empty_tables_when_requested_year_has_no_data(client: TestClient):
+    response = client.get("/companies/4170/kpis", params={"years": "2023"})
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["years"] == [2023]
+    assert payload["annual"] == {"columns": [], "rows": []}
+    assert payload["quarterly"] == {"columns": [], "rows": []}
 
 
 def test_refresh_status_returns_operational_rows(client: TestClient):

--- a/src/settings.py
+++ b/src/settings.py
@@ -31,6 +31,17 @@ def _default_project_root() -> Path:
     return Path(__file__).resolve().parent.parent
 
 
+def _resolve_shared_repo_root_for_worktree(project_root: Path) -> Path | None:
+    lane_dir = project_root.parent
+    worktrees_dir = lane_dir.parent
+    claude_dir = worktrees_dir.parent
+    repo_root = claude_dir.parent
+
+    if worktrees_dir.name != "worktrees" or claude_dir.name != ".claude":
+        return None
+    return repo_root.resolve()
+
+
 def _resolve_path(base_dir: Path, raw_path: str | None, fallback: Path) -> Path:
     if not raw_path:
         return fallback
@@ -38,6 +49,20 @@ def _resolve_path(base_dir: Path, raw_path: str | None, fallback: Path) -> Path:
     if candidate.is_absolute():
         return candidate
     return (base_dir / candidate).resolve()
+
+
+def _prefer_existing_shared_path(
+    local_path: Path,
+    shared_repo_root: Path | None,
+    relative_path: Path,
+) -> Path:
+    if local_path.exists() or shared_repo_root is None:
+        return local_path
+
+    shared_candidate = (shared_repo_root / relative_path).resolve()
+    if shared_candidate.exists():
+        return shared_candidate
+    return local_path
 
 
 @dataclass(frozen=True)
@@ -85,6 +110,7 @@ class AppSettings:
 
 def build_settings(project_root: Path | None = None) -> AppSettings:
     resolved_root = Path(project_root).resolve() if project_root else _default_project_root()
+    shared_repo_root = _resolve_shared_repo_root_for_worktree(resolved_root)
 
     data_dir = _resolve_path(
         resolved_root,
@@ -131,6 +157,29 @@ def build_settings(project_root: Path | None = None) -> AppSettings:
         os.getenv("SQLITE_PATH"),
         db_dir / "cvm_financials.db",
     )
+    db_path = _prefer_existing_shared_path(
+        db_path,
+        shared_repo_root,
+        Path("data/db/cvm_financials.db"),
+    )
+    canonical_accounts_path = _prefer_existing_shared_path(
+        _resolve_path(
+            resolved_root,
+            os.getenv("CVM_CANONICAL_ACCOUNTS_PATH"),
+            data_dir / "canonical_accounts.csv",
+        ),
+        shared_repo_root,
+        Path("data/canonical_accounts.csv"),
+    )
+    account_dictionary_path = _prefer_existing_shared_path(
+        _resolve_path(
+            resolved_root,
+            os.getenv("CVM_ACCOUNT_DICTIONARY_PATH"),
+            data_dir / "cvm_account_dictionary.csv",
+        ),
+        shared_repo_root,
+        Path("data/cvm_account_dictionary.csv"),
+    )
 
     paths = AppPaths(
         project_root=resolved_root,
@@ -145,16 +194,8 @@ def build_settings(project_root: Path | None = None) -> AppSettings:
         metadata_dir=metadata_dir,
         db_dir=db_dir,
         db_path=db_path,
-        canonical_accounts_path=_resolve_path(
-            resolved_root,
-            os.getenv("CVM_CANONICAL_ACCOUNTS_PATH"),
-            data_dir / "canonical_accounts.csv",
-        ),
-        account_dictionary_path=_resolve_path(
-            resolved_root,
-            os.getenv("CVM_ACCOUNT_DICTIONARY_PATH"),
-            data_dir / "cvm_account_dictionary.csv",
-        ),
+        canonical_accounts_path=canonical_accounts_path,
+        account_dictionary_path=account_dictionary_path,
         active_universe_cache_path=cache_dir / "active_universe_cache.json",
         base_health_snapshot_path=cache_dir / "base_health_snapshot.json",
         processed_presence_index_path=cache_dir / "processed_presence_index.json",

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from src.settings import build_settings
+
+
+def test_build_settings_prefers_shared_runtime_files_inside_task_worktree(tmp_path):
+    repo_root = tmp_path / "repo"
+    worktree_root = repo_root / ".claude" / "worktrees" / "backend" / "33-postgres-contract-hardening"
+    shared_db_path = repo_root / "data" / "db" / "cvm_financials.db"
+    shared_canonical_path = repo_root / "data" / "canonical_accounts.csv"
+    shared_dictionary_path = repo_root / "data" / "cvm_account_dictionary.csv"
+
+    worktree_root.mkdir(parents=True, exist_ok=True)
+    shared_db_path.parent.mkdir(parents=True, exist_ok=True)
+    shared_db_path.touch()
+    shared_canonical_path.write_text("CD_CONTA,STANDARD_NAME\n1,ATIVO\n", encoding="utf-8")
+    shared_dictionary_path.write_text("CD_CONTA,STANDARD_NAME\n1,ATIVO\n", encoding="utf-8")
+
+    settings = build_settings(project_root=worktree_root)
+
+    assert settings.paths.db_path == shared_db_path.resolve()
+    assert settings.paths.canonical_accounts_path == shared_canonical_path.resolve()
+    assert settings.paths.account_dictionary_path == shared_dictionary_path.resolve()
+    assert settings.paths.cache_dir == (worktree_root / "data" / "cache").resolve()
+
+
+def test_build_settings_keeps_local_runtime_files_when_worktree_has_own_copy(tmp_path):
+    repo_root = tmp_path / "repo"
+    worktree_root = repo_root / ".claude" / "worktrees" / "backend" / "33-postgres-contract-hardening"
+    local_db_path = worktree_root / "data" / "db" / "cvm_financials.db"
+    local_canonical_path = worktree_root / "data" / "canonical_accounts.csv"
+    local_dictionary_path = worktree_root / "data" / "cvm_account_dictionary.csv"
+
+    local_db_path.parent.mkdir(parents=True, exist_ok=True)
+    local_db_path.touch()
+    local_canonical_path.write_text("CD_CONTA,STANDARD_NAME\n1,ATIVO\n", encoding="utf-8")
+    local_dictionary_path.write_text("CD_CONTA,STANDARD_NAME\n1,ATIVO\n", encoding="utf-8")
+
+    settings = build_settings(project_root=worktree_root)
+
+    assert settings.paths.db_path == local_db_path.resolve()
+    assert settings.paths.canonical_accounts_path == local_canonical_path.resolve()
+    assert settings.paths.account_dictionary_path == local_dictionary_path.resolve()


### PR DESCRIPTION
﻿## Issue

Closes #33

## Resumo

- ordena o parametro `years` na camada HTTP para estabilizar o contrato consumido pelo web app
- amplia a suite da API para cobrir filtros desconhecidos, empresas sem dados e respostas vazias/parciais sem quebrar o shape
- torna a fixture da API portavel para SQLite e PostgreSQL explicito via `API_TEST_DATABASE_URL`
- faz o runtime em worktree reutilizar `db` e arquivos canonicos compartilhados quando a task roda em `.claude/worktrees/**`

## Paralelismo

- lane da task: `lane:backend`
- worktree usada: `.claude/worktrees/backend/33-postgres-contract-hardening/`
- esta e a unica PR oficial da task: `sim`
- risco da task: `risk:shared`
- write-set principal: `src/settings.py`, `apps/api/app/dependencies.py`, `apps/api/tests/**`, `tests/test_settings.py`
- coordenacao com outras tasks/PRs: toca `critical-runtime`; PR abre em draft por politica

## Compatibilidade

- politica aplicada: `additive-only`
- impacto em API, schema ou docs publicos: sem endpoint novo; apenas ordenacao estavel de `years`, cobertura de cenarios vazios/parciais e suporte operacional a worktree

## Validacao

- `pytest apps/api/tests -q`
- `pytest tests/test_settings.py tests/test_startup.py tests/test_read_service.py -q`
- `python scripts/runtime_doctor.py --require-db --table financial_reports --table companies --require-canonical`
- `python scripts/db_portability_smoke.py --write-check`
- `pytest tests -q`
- `cd apps/web && npm run test:unit`
- `cd apps/web && npm run typecheck`
- `cd apps/web && npm run test:e2e`

## Limite conhecido

- o gate com PostgreSQL real continua dependente de infraestrutura externa neste ambiente atual; nao havia `DATABASE_URL`, `docker` nem `psql` disponiveis para fechar esse trecho aqui
