### PR TITLE
feat(api): expor endpoint GET /companies/{cd_cvm}/summary na V2

### DIFF
--- a/apps/api/app/presenters.py
+++ b/apps/api/app/presenters.py
@@ -14,6 +14,7 @@ from src.contracts import (
     KPIBundle,
     RefreshStatusDTO,
     StatementMatrix,
+    StatementSummaryDTO,
 )
 from src.startup import StartupIssue
 
@@ -116,6 +117,18 @@ class KPIBundlePayload(BaseModel):
     years: list[int]
     annual: TabularDataPayload
     quarterly: TabularDataPayload
+
+
+class SummaryBlockPayload(BaseModel):
+    stmt_type: str
+    title: str
+    table: TabularDataPayload
+
+
+class StatementSummaryPayload(BaseModel):
+    cd_cvm: int
+    years: list[int]
+    blocks: list[SummaryBlockPayload]
 
 
 class RefreshStatusPayload(BaseModel):
@@ -225,6 +238,18 @@ def present_kpis(dto: KPIBundle) -> KPIBundlePayload:
     payload["annual"] = _normalize_tabular_payload(payload["annual"])
     payload["quarterly"] = _normalize_tabular_payload(payload["quarterly"])
     return KPIBundlePayload(**payload)
+
+
+def present_statement_summary(dto: StatementSummaryDTO) -> StatementSummaryPayload:
+    blocks = [
+        SummaryBlockPayload(
+            stmt_type=b.stmt_type,
+            title=b.title,
+            table=TabularDataPayload(**_normalize_tabular_payload(b.table.to_dict())),
+        )
+        for b in dto.blocks
+    ]
+    return StatementSummaryPayload(cd_cvm=dto.cd_cvm, years=list(dto.years), blocks=blocks)
 
 
 def present_refresh_status(rows: list[RefreshStatusDTO]) -> list[RefreshStatusPayload]:

--- a/apps/api/app/routes/companies.py
+++ b/apps/api/app/routes/companies.py
@@ -17,11 +17,13 @@ from apps.api.app.presenters import (
     CompanyInfoPayload,
     KPIBundlePayload,
     StatementMatrixPayload,
+    StatementSummaryPayload,
     present_company_directory_page,
     present_company_filters,
     present_company_info,
     present_kpis,
     present_statement,
+    present_statement_summary,
 )
 from src.read_service import CVMReadService
 
@@ -129,3 +131,20 @@ def get_company_kpis(
     coerce_company(cd_cvm, service)
     bundle = service.get_kpi_bundle(cd_cvm=cd_cvm, years=years)
     return present_kpis(bundle)
+
+
+@router.get(
+    "/companies/{cd_cvm}/summary",
+    response_model=StatementSummaryPayload,
+    summary="Retorna o resumo condensado multi-bloco das demonstracoes financeiras.",
+)
+def get_company_summary(
+    cd_cvm: int,
+    request: Request,
+    years: list[int] = Depends(years_dependency),
+    service: CVMReadService = Depends(get_read_service),
+) -> StatementSummaryPayload:
+    ensure_api_ready(get_settings(request))
+    coerce_company(cd_cvm, service)
+    dto = service.get_statement_summary(cd_cvm=cd_cvm, years=years)
+    return present_statement_summary(dto)

--- a/apps/api/tests/test_api_contract.py
+++ b/apps/api/tests/test_api_contract.py
@@ -242,3 +242,98 @@ def test_companies_reject_invalid_page_size(client: TestClient):
 
     assert response.status_code == 422
     assert response.json()["error"]["code"] == "validation_error"
+
+
+# ---------------------------------------------------------------------------
+# Summary endpoint
+# ---------------------------------------------------------------------------
+
+
+def test_company_summary_returns_blocks(client: TestClient):
+    response = client.get("/companies/9512/summary", params={"years": "2023,2024"})
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["cd_cvm"] == 9512
+    assert payload["years"] == [2023, 2024]
+    assert len(payload["blocks"]) >= 1
+    assert payload["blocks"][0]["stmt_type"] in {"DRE", "BPA", "BPP", "DFC"}
+
+
+def test_company_summary_block_columns_contain_required_fields(client: TestClient):
+    response = client.get("/companies/9512/summary", params={"years": "2023,2024"})
+
+    assert response.status_code == 200
+    for block in response.json()["blocks"]:
+        cols = block["table"]["columns"]
+        assert "CD_CONTA" in cols
+        assert "LABEL" in cols
+        assert "IS_SUBTOTAL" in cols
+
+
+def test_company_summary_is_subtotal_propagation(client: TestClient):
+    response = client.get("/companies/9512/summary", params={"years": "2023"})
+
+    assert response.status_code == 200
+    dre_block = next((b for b in response.json()["blocks"] if b["stmt_type"] == "DRE"), None)
+    assert dre_block is not None
+    row_3_01 = next((r for r in dre_block["table"]["rows"] if r["CD_CONTA"] == "3.01"), None)
+    assert row_3_01 is not None
+    assert row_3_01["IS_SUBTOTAL"] is True
+
+
+def test_company_summary_empty_blocks_when_no_data(client: TestClient):
+    # year 1990 has no data for PETROBRAS → blocks should be []
+    response = client.get("/companies/9512/summary", params={"years": "1990"})
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["blocks"] == []
+
+
+def test_company_summary_404_unknown_company(client: TestClient):
+    response = client.get("/companies/999999/summary", params={"years": "2024"})
+
+    assert response.status_code == 404
+    assert response.json()["error"]["code"] == "not_found"
+
+
+def test_company_summary_422_invalid_years(client: TestClient):
+    response = client.get("/companies/9512/summary", params={"years": "2024,foo"})
+
+    assert response.status_code == 422
+    assert response.json()["error"]["code"] == "invalid_request"
+
+
+def test_company_summary_422_duplicate_years(client: TestClient):
+    response = client.get("/companies/9512/summary", params={"years": "2024,2024"})
+
+    assert response.status_code == 422
+    assert response.json()["error"]["code"] == "invalid_request"
+
+
+def test_company_summary_years_sorted_stable(client: TestClient):
+    response = client.get("/companies/9512/summary", params={"years": "2024,2023"})
+
+    assert response.status_code == 200
+    assert response.json()["years"] == [2023, 2024]
+
+
+def test_company_summary_single_year_columns(client: TestClient):
+    response = client.get("/companies/9512/summary", params={"years": "2024"})
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["years"] == [2024]
+    assert len(payload["blocks"]) >= 1
+    first_block = payload["blocks"][0]
+    assert "2024" in first_block["table"]["columns"]
+    assert "2023" not in first_block["table"]["columns"]
+
+
+def test_company_summary_blocks_have_non_empty_titles(client: TestClient):
+    response = client.get("/companies/9512/summary", params={"years": "2023"})
+
+    assert response.status_code == 200
+    for block in response.json()["blocks"]:
+        assert isinstance(block["title"], str) and len(block["title"]) > 0

--- a/apps/api/tests/test_presenters.py
+++ b/apps/api/tests/test_presenters.py
@@ -9,6 +9,7 @@ from apps.api.app.presenters import (
     present_kpis,
     present_refresh_status,
     present_statement,
+    present_statement_summary,
 )
 from src.contracts import (
     CompanyDirectoryAppliedFilters,
@@ -24,6 +25,8 @@ from src.contracts import (
     KPIBundle,
     RefreshStatusDTO,
     StatementMatrix,
+    StatementSummaryDTO,
+    SummaryBlockDTO,
     TabularData,
 )
 
@@ -183,3 +186,34 @@ def test_presenters_serialize_dtos_without_raw_pandas_objects():
     )
     assert health.per_year[0].year == 2023
     assert health.prioritized_companies[0].years_missing == [2024]
+
+
+def test_summary_presenter_serializes_dto_without_raw_pandas():
+    dto = StatementSummaryDTO(
+        cd_cvm=9512,
+        years=(2023, 2024),
+        blocks=(
+            SummaryBlockDTO(
+                stmt_type="DRE",
+                title="DRE — Resumo Condensado",
+                table=TabularData(
+                    columns=("CD_CONTA", "LABEL", "IS_SUBTOTAL", "2023", "2024"),
+                    rows=(
+                        {"CD_CONTA": "3.01", "LABEL": "Receita", "IS_SUBTOTAL": True, "2023": 1000.0, "2024": 1100.0},
+                        {"CD_CONTA": "3.03", "LABEL": "Resultado Bruto", "IS_SUBTOTAL": True, "2023": 400.0, "2024": None},
+                    ),
+                ),
+            ),
+        ),
+    )
+    payload = present_statement_summary(dto)
+
+    assert payload.cd_cvm == 9512
+    assert payload.years == [2023, 2024]
+    assert len(payload.blocks) == 1
+    block = payload.blocks[0]
+    assert block.stmt_type == "DRE"
+    assert block.title == "DRE — Resumo Condensado"
+    assert block.table.columns == ["CD_CONTA", "LABEL", "IS_SUBTOTAL", "2023", "2024"]
+    assert block.table.rows[0]["IS_SUBTOTAL"] is True
+    assert block.table.rows[1]["2024"] is None

--- a/docs/V2_API_CONTRACT.md
+++ b/docs/V2_API_CONTRACT.md
@@ -199,6 +199,49 @@ Resposta exemplo:
 }
 ```
 
+### `GET /companies/{cd_cvm}/summary?years=`
+
+Parametros:
+- `years`: obrigatorio; CSV de inteiros sem duplicatas, ex. `2023,2024`
+
+DTO de saida:
+- `src.contracts.StatementSummaryDTO`
+
+Resposta exemplo:
+
+```json
+{
+  "cd_cvm": 9512,
+  "years": [2023, 2024],
+  "blocks": [
+    {
+      "stmt_type": "DRE",
+      "title": "DRE — Resumo Condensado",
+      "table": {
+        "columns": ["CD_CONTA", "LABEL", "IS_SUBTOTAL", "2023", "2024"],
+        "rows": [
+          {
+            "CD_CONTA": "3.01",
+            "LABEL": "Receita",
+            "IS_SUBTOTAL": true,
+            "2023": 1000.0,
+            "2024": 1100.0
+          }
+        ]
+      }
+    }
+  ]
+}
+```
+
+Regras do endpoint:
+- `blocks` contem apenas demonstracoes com dados disponiveis para os anos solicitados
+- ordem dos blocos: DRE, BPA, BPP, DFC (quando presentes)
+- cada bloco expoe apenas linhas de resumo condensado (codigos subtotais e filhos diretos selecionados)
+- `IS_SUBTOTAL` e `true` para codigos marcados como subtotais em cada demonstracao
+- se nenhuma demonstracao tiver dados, `blocks` retorna `[]` (nao e erro)
+- `years` no response reflete exatamente os anos solicitados, ordenados ascendente
+
 ### `GET /refresh-status?cd_cvm=`
 
 Parametros:

--- a/src/contracts.py
+++ b/src/contracts.py
@@ -267,6 +267,30 @@ class KPIBundle:
 
 
 @dataclass(frozen=True)
+class SummaryBlockDTO:
+    stmt_type: str
+    title: str
+    table: TabularData
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"stmt_type": self.stmt_type, "title": self.title, "table": self.table.to_dict()}
+
+
+@dataclass(frozen=True)
+class StatementSummaryDTO:
+    cd_cvm: int
+    years: tuple[int, ...]
+    blocks: tuple[SummaryBlockDTO, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "cd_cvm": int(self.cd_cvm),
+            "years": list(self.years),
+            "blocks": [b.to_dict() for b in self.blocks],
+        }
+
+
+@dataclass(frozen=True)
 class RefreshStatusDTO:
     cd_cvm: int
     company_name: str

--- a/src/read_service.py
+++ b/src/read_service.py
@@ -18,8 +18,11 @@ from src.contracts import (
     KPIBundle,
     RefreshStatusDTO,
     StatementMatrix,
+    StatementSummaryDTO,
+    SummaryBlockDTO,
     TabularData,
 )
+from src.statement_summary import build_general_summary_blocks
 from src.db import build_engine
 from src.kpi_engine import compute_all_kpis, compute_quarterly_kpis
 from src.query_layer import CVMQueryLayer
@@ -196,6 +199,32 @@ class CVMReadService:
             years=tuple(int(year) for year in years),
             annual=TabularData.from_dataframe(annual),
             quarterly=TabularData.from_dataframe(quarterly),
+        )
+
+    def get_statement_summary(self, cd_cvm: int, years: list[int]) -> StatementSummaryDTO:
+        stmt_types = ["DRE", "BPA", "BPP", "DFC"]
+        statements = {
+            s: self.query_layer.get_statement(
+                cd_cvm=cd_cvm,
+                years=years,
+                stmt_type=s,
+                exclude_conflicts=True,
+            )
+            for s in stmt_types
+        }
+        raw_blocks = build_general_summary_blocks(statements)
+        blocks = tuple(
+            SummaryBlockDTO(
+                stmt_type=b.stmt_type,
+                title=b.title,
+                table=TabularData.from_dataframe(b.rows),
+            )
+            for b in raw_blocks
+        )
+        return StatementSummaryDTO(
+            cd_cvm=int(cd_cvm),
+            years=tuple(sorted(int(y) for y in years)),
+            blocks=blocks,
         )
 
     def get_health_snapshot(


### PR DESCRIPTION
## Summary

- Expõe `src/statement_summary.py` (já existente) via API V2 como endpoint `GET /companies/{cd_cvm}/summary?years=`
- Retorna visão condensada multi-bloco das demonstrações financeiras (DRE, BPA, BPP, DFC) com `IS_SUBTOTAL` propagado
- Zero novas dependências externas — reutiliza padrões existentes do contrato V2

## Compatibilidade

- Adição pura: novo endpoint `GET /companies/{cd_cvm}/summary` — nenhum endpoint existente foi alterado
- Novos DTOs `SummaryBlockDTO` e `StatementSummaryDTO` são additive-only em `src/contracts.py`
- Novos modelos Pydantic `SummaryBlockPayload` e `StatementSummaryPayload` são additive-only em `presenters.py`
- Sem breaking change no contrato público — todos os endpoints, DTOs e modelos existentes permanecem inalterados

## Changes

- `src/contracts.py` — `SummaryBlockDTO`, `StatementSummaryDTO`
- `src/read_service.py` — `get_statement_summary()`
- `apps/api/app/presenters.py` — `SummaryBlockPayload`, `StatementSummaryPayload`, `present_statement_summary()`
- `apps/api/app/routes/companies.py` — rota `GET /companies/{cd_cvm}/summary`
- `apps/api/tests/test_api_contract.py` — 10 testes de contrato
- `apps/api/tests/test_presenters.py` — 1 teste de presenter
- `docs/V2_API_CONTRACT.md` — documentação do novo endpoint

## Test plan

- [x] `pytest apps/api/tests/ -q` → 33 passed
- [x] `pytest tests/ -q` → 125 passed
- [x] Total: 158 testes green, 0 failures

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)