### PR TITLE
[Task 42] Promover docs do PG-04 /comparar para live

### DIFF
--- a/docs/INTERFACE_MAP.md
+++ b/docs/INTERFACE_MAP.md
@@ -1,11 +1,11 @@
-# Interface Map — Frontend routes x API endpoints
+# Interface Map - Frontend routes x API endpoints
 
-**Leitura obrigatória antes de tocar `apps/web` ou `apps/api`.**
+**Leitura obrigatoria antes de tocar `apps/web` ou `apps/api`.**
 
-Este documento é a fonte de verdade sobre quais rotas o frontend tem, qual é o
+Este documento e a fonte de verdade sobre quais rotas o frontend tem, qual e o
 status de cada uma, e quais endpoints de API cada rota consome. Qualquer IA ou
-pessoa que trabalhe em qualquer uma das duas áreas deve atualizar este arquivo
-**antes** de começar a implementação.
+pessoa que trabalhe em qualquer uma das duas areas deve atualizar este arquivo
+**antes** de comecar a implementacao.
 
 > Contratos HTTP detalhados: `docs/V2_API_CONTRACT.md`
 > Hierarquia de rotas e IA de produto: `docs/SITEMAP.MD`
@@ -15,11 +15,11 @@ pessoa que trabalhe em qualquer uma das duas áreas deve atualizar este arquivo
 
 ## Como manter este documento
 
-- **Nova rota no frontend**: adicione a seção, marque como `em desenvolvimento`,
-  liste os endpoints necessários. Se algum não existir ainda, registre em
-  [Pendências de backend](#pendencias-de-backend).
-- **Novo endpoint no backend**: adicione na [tabela inversa](#tabela-inversa-endpoint--rotas-que-o-usam).
-  Verifique se alguma rota em _Pendências_ esperava por ele e atualize o status.
+- **Nova rota no frontend**: adicione a secao, marque como `em desenvolvimento`,
+  liste os endpoints necessarios. Se algum nao existir ainda, registre em
+  [Pendencias de backend](#pendencias-de-backend).
+- **Novo endpoint no backend**: adicione na [tabela inversa](#tabela-inversa-endpoint-x-rotas-que-o-usam).
+  Verifique se alguma rota em _Pendencias_ esperava por ele e atualize o status.
 - **Rota vai ao ar**: mude o status de `em desenvolvimento` para `live`.
 - **Endpoint alterado ou removido**: verifique a tabela inversa, atualize todas as
   rotas afetadas, registre breaking change no PR.
@@ -28,104 +28,105 @@ pessoa que trabalhe em qualquer uma das duas áreas deve atualizar este arquivo
 
 ## Rotas do frontend
 
-### PG-01 — `/` (Home) `live`
+### PG-01 - `/` (Home) `live`
 
-**Objetivo**: roteador de entrada — leva o usuário ao caminho de análise mais curto.
+**Objetivo**: roteador de entrada - leva o usuario ao caminho de analise mais curto.
 
 **Endpoints consumidos**:
 
 | Endpoint | Params | Para que serve |
 |---|---|---|
-| `GET /health` | — | Trust strip / sinal de saúde da API |
-| `GET /companies` | `page=1&page_size=8` | Sugestões rápidas de empresas na home |
+| `GET /health` | - | Trust strip / sinal de saude da API |
+| `GET /companies` | `page=1&page_size=8` | Sugestoes rapidas de empresas na home |
 
 **Rota interna Next.js**:
-- `GET /api/company-search?q=<termo>` → chama `GET /companies` com `search=q` e
-  retorna até 6 itens para o autocomplete do hero.
+- `GET /api/company-search?q=<termo>` -> chama `GET /companies` com `search=q` e
+  retorna ate 6 itens para o autocomplete do hero.
 
 ---
 
-### PG-02 — `/empresas` (Companies Hub) `live`
+### PG-02 - `/empresas` (Companies Hub) `live`
 
-**Objetivo**: descoberta e seleção de empresa por busca e filtro de setor.
+**Objetivo**: descoberta e selecao de empresa por busca e filtro de setor.
 
 **Endpoints consumidos**:
 
 | Endpoint | Params | Para que serve |
 |---|---|---|
 | `GET /companies` | `search=`, `sector=`, `page=`, `page_size=` | Lista paginada de empresas |
-| `GET /companies/filters` | — | Opções de setor para o filtro |
+| `GET /companies/filters` | - | Opcoes de setor para o filtro |
 
-**Query params públicos da rota**: `?busca=&setor=&pagina=`
+**Query params publicos da rota**: `?busca=&setor=&pagina=`
 
 ---
 
-### PG-03 — `/empresas/[cd_cvm]` (Company Detail) `live`
+### PG-03 - `/empresas/[cd_cvm]` (Company Detail) `live`
 
-**Objetivo**: análise completa de uma empresa — KPIs, demonstrações e contexto.
+**Objetivo**: analise completa de uma empresa - KPIs, demonstracoes e contexto.
 
 **Endpoints consumidos**:
 
 | Endpoint | Params | Para que serve |
 |---|---|---|
-| `GET /companies/{cd_cvm}` | — | Metadados da empresa (header) |
-| `GET /companies/{cd_cvm}/years` | — | Anos disponíveis (seletor de período) |
-| `GET /companies/{cd_cvm}/statements` | `stmt=DRE\|BPA\|BPP\|DFC`, `years=2023,2024` | Aba Demonstrações |
-| `GET /companies/{cd_cvm}/kpis` | `years=2023,2024` | Aba Visão Geral |
+| `GET /companies/{cd_cvm}` | - | Metadados da empresa (header) |
+| `GET /companies/{cd_cvm}/years` | - | Anos disponiveis (seletor de periodo) |
+| `GET /companies/{cd_cvm}/statements` | `stmt=DRE\|BPA\|BPP\|DFC`, `years=2023,2024` | Aba Demonstracoes |
+| `GET /companies/{cd_cvm}/kpis` | `years=2023,2024` | Aba Visao Geral |
 
-**Query params públicos da rota**: `?anos=2023,2024&aba=visao-geral\|demonstracoes&stmt=DRE\|BPA\|BPP\|DFC`
+**Query params publicos da rota**: `?anos=2023,2024&aba=visao-geral\|demonstracoes&stmt=DRE\|BPA\|BPP\|DFC`
 
 ---
 
-### PG-04 — `/comparar` (Compare) `em desenvolvimento`
+### PG-04 - `/comparar` (Compare) `live`
 
-**Objetivo**: comparação lado a lado entre ao menos 2 empresas com base em KPIs.
+**Objetivo**: comparacao lado a lado entre ao menos 2 empresas com base em KPIs.
 
-**Status**: componentes, data layer e link de navegação existem. Falta validação
-E2E end-to-end e smoke do fluxo completo.
+**Status**: rota entregue e integrada na navegacao principal. O fluxo cobre
+estado inicial, deep-link por `ids`/`anos`, periodo em comum, fallback para
+ausencia de interseccao anual e erro parcial sem derrubar a tela.
 
-**Não requer novos endpoints** — agrega chamadas existentes em paralelo.
+**Nao requer novos endpoints** - agrega chamadas existentes em paralelo.
 
 **Endpoints consumidos**:
 
 | Endpoint | Params | Para que serve |
 |---|---|---|
-| `GET /companies` | `page=1&page_size=8` | Sugestões rápidas de empresas no seletor |
-| `GET /companies/{cd_cvm}` | — | Metadados de cada empresa selecionada (paralelo) |
-| `GET /companies/{cd_cvm}/years` | — | Anos disponíveis por empresa (paralelo) |
-| `GET /companies/{cd_cvm}/kpis` | `years=<intersecção>` | KPI bundles por empresa (paralelo) |
+| `GET /companies` | `page=1&page_size=8` | Sugestoes rapidas de empresas no seletor |
+| `GET /companies/{cd_cvm}` | - | Metadados de cada empresa selecionada (paralelo) |
+| `GET /companies/{cd_cvm}/years` | - | Anos disponiveis por empresa (paralelo) |
+| `GET /companies/{cd_cvm}/kpis` | `years=<interseccao>` | KPI bundles por empresa (paralelo) |
 
-**Query params públicos da rota**: `?ids=cd_cvm1,cd_cvm2,...&anos=2022,2023`
+**Query params publicos da rota**: `?ids=cd_cvm1,cd_cvm2,...&anos=2022,2023`
 
 **Arquivos relevantes**:
-- `apps/web/app/comparar/page.tsx` — page component
-- `apps/web/lib/compare-page-data.ts` — orquestração das chamadas paralelas
-- `apps/web/lib/compare-utils.ts` — helpers de interseção de anos e montagem de linhas
-- `apps/web/components/compare/` — CompareSelector, CompareKpiTable, CompareTracker
+- `apps/web/app/comparar/page.tsx` - page component
+- `apps/web/lib/compare-page-data.ts` - orquestracao das chamadas paralelas
+- `apps/web/lib/compare-utils.ts` - helpers de interseccao de anos e montagem de linhas
+- `apps/web/components/compare/` - CompareSelector, CompareKpiTable, CompareTracker
 
 ---
 
-### PG-05 — `/setores` (Sectors Hub) `planejado`
+### PG-05 - `/setores` (Sectors Hub) `planejado`
 
 **Objetivo**: descoberta de setores com ranking de KPIs agregados.
 
-**Status**: não iniciado. **Aguarda endpoints de backend** (ver Pendências).
+**Status**: nao iniciado. **Aguarda endpoints de backend** (ver Pendencias).
 
-**Endpoints necessários (não existem ainda)**:
+**Endpoints necessarios (nao existem ainda)**:
 
 | Endpoint | Dados esperados |
 |---|---|
-| `GET /sectors` | Lista de setores com slug, nome, contagem de empresas, KPIs médios (ROE, margem, etc.) |
+| `GET /sectors` | Lista de setores com slug, nome, contagem de empresas, KPIs medios (ROE, margem, etc.) |
 
 ---
 
-### PG-06 — `/setores/[slug]` (Sector Detail) `planejado`
+### PG-06 - `/setores/[slug]` (Sector Detail) `planejado`
 
-**Objetivo**: análise profunda de um setor — empresas do setor, ranking de KPIs, contexto.
+**Objetivo**: analise profunda de um setor - empresas do setor, ranking de KPIs, contexto.
 
-**Status**: não iniciado. **Aguarda endpoints de backend** (ver Pendências).
+**Status**: nao iniciado. **Aguarda endpoints de backend** (ver Pendencias).
 
-**Endpoints necessários (não existem ainda)**:
+**Endpoints necessarios (nao existem ainda)**:
 
 | Endpoint | Dados esperados |
 |---|---|
@@ -133,56 +134,56 @@ E2E end-to-end e smoke do fluxo completo.
 
 ---
 
-### PG-07 — `/kpis` (KPI Hub) `planejado`
+### PG-07 - `/kpis` (KPI Hub) `planejado`
 
-**Objetivo**: catálogo de KPIs com definições e top performers.
+**Objetivo**: catalogo de KPIs com definicoes e top performers.
 
-**Status**: não iniciado. **Aguarda endpoints de backend** (ver Pendências).
+**Status**: nao iniciado. **Aguarda endpoints de backend** (ver Pendencias).
 
-**Endpoints necessários (não existem ainda)**:
-
-| Endpoint | Dados esperados |
-|---|---|
-| `GET /kpis` | Catálogo de KPIs com id, nome, fórmula, unidade, categoria |
-
----
-
-### PG-08 — `/kpis/[kpi_id]` (KPI Detail) `planejado`
-
-**Objetivo**: interpretação de um KPI com benchmark setorial e top empresas.
-
-**Status**: não iniciado. **Aguarda endpoints de backend** (ver Pendências).
-
-**Endpoints necessários (não existem ainda)**:
+**Endpoints necessarios (nao existem ainda)**:
 
 | Endpoint | Dados esperados |
 |---|---|
-| `GET /kpis/{kpi_id}` | Definição + distribuição setorial + top empresas por KPI |
+| `GET /kpis` | Catalogo de KPIs com id, nome, formula, unidade, categoria |
 
 ---
 
-### PG-09 — `/macro` (Macro Hub) `planejado`
+### PG-08 - `/kpis/[kpi_id]` (KPI Detail) `planejado`
 
-**Objetivo**: hub de indicadores macroeconômicos como contexto para análise.
+**Objetivo**: interpretacao de um KPI com benchmark setorial e top empresas.
 
-**Status**: não iniciado. Fonte de dados é externa (não vem do banco CVM).
+**Status**: nao iniciado. **Aguarda endpoints de backend** (ver Pendencias).
 
----
+**Endpoints necessarios (nao existem ainda)**:
 
-### PG-10 — `/macro/[indicator_id]` (Macro Detail) `planejado`
-
-**Status**: não iniciado. Depende de definição de fonte de dados macro.
-
----
-
-### `/design-system` — tooling interno
-
-**Status**: showcase interno de tokens e componentes. Não aparece na navegação
-de produto. Não consome endpoints de API.
+| Endpoint | Dados esperados |
+|---|---|
+| `GET /kpis/{kpi_id}` | Definicao + distribuicao setorial + top empresas por KPI |
 
 ---
 
-## Tabela inversa — endpoint → rotas que o usam
+### PG-09 - `/macro` (Macro Hub) `planejado`
+
+**Objetivo**: hub de indicadores macroeconomicos como contexto para analise.
+
+**Status**: nao iniciado. Fonte de dados e externa (nao vem do banco CVM).
+
+---
+
+### PG-10 - `/macro/[indicator_id]` (Macro Detail) `planejado`
+
+**Status**: nao iniciado. Depende de definicao de fonte de dados macro.
+
+---
+
+### `/design-system` - tooling interno
+
+**Status**: showcase interno de tokens e componentes. Nao aparece na navegacao
+de produto. Nao consome endpoints de API.
+
+---
+
+## Tabela inversa - endpoint x rotas que o usam
 
 | Endpoint | Rotas que consomem |
 |---|---|
@@ -193,51 +194,51 @@ de produto. Não consome endpoints de API.
 | `GET /companies/{cd_cvm}/years` | `/empresas/[cd_cvm]`, `/comparar` |
 | `GET /companies/{cd_cvm}/statements` | `/empresas/[cd_cvm]` |
 | `GET /companies/{cd_cvm}/kpis` | `/empresas/[cd_cvm]`, `/comparar` |
-| `GET /refresh-status` | Não consumido pelo frontend ainda |
+| `GET /refresh-status` | Nao consumido pelo frontend ainda |
 | `GET /base-health` | `/` (parcialmente, se trust strip expandir) |
 
 ---
 
-## Pendências de backend
+## Pendencias de backend
 
-Endpoints que o frontend vai precisar mas que ainda não existem. Antes de
+Endpoints que o frontend vai precisar mas que ainda nao existem. Antes de
 iniciar PG-05 ou posterior, o backend precisa cobrir a linha correspondente.
 
-| Rota frontend | Endpoint necessário | Dados mínimos esperados | Status |
+| Rota frontend | Endpoint necessario | Dados minimos esperados | Status |
 |---|---|---|---|
-| PG-05 `/setores` | `GET /sectors` | slug, nome, n_empresas, KPI médio (ROE, margem) | Não planejado |
-| PG-06 `/setores/[slug]` | `GET /sectors/{slug}` | metadados + empresas + KPIs por ano | Não planejado |
-| PG-07 `/kpis` | `GET /kpis` | id, nome, fórmula, unidade, categoria | Não planejado |
-| PG-08 `/kpis/[kpi_id]` | `GET /kpis/{kpi_id}` | definição + distribuição + top empresas | Não planejado |
+| PG-05 `/setores` | `GET /sectors` | slug, nome, n_empresas, KPI medio (ROE, margem) | Nao planejado |
+| PG-06 `/setores/[slug]` | `GET /sectors/{slug}` | metadados + empresas + KPIs por ano | Nao planejado |
+| PG-07 `/kpis` | `GET /kpis` | id, nome, formula, unidade, categoria | Nao planejado |
+| PG-08 `/kpis/[kpi_id]` | `GET /kpis/{kpi_id}` | definicao + distribuicao + top empresas | Nao planejado |
 
-**Protocolo**: ao criar um task de backend para qualquer linha acima, vincule
+**Protocolo**: ao criar uma task de backend para qualquer linha acima, vincule
 este documento no corpo da issue e atualize o status da linha quando o endpoint
 for entregue.
 
 ---
 
-## Protocolo de mudança cross-área
+## Protocolo de mudanca cross-area
 
 ### Adicionando rota no frontend
 
-1. Adicione a seção neste arquivo com status `em desenvolvimento`.
-2. Liste os endpoints necessários. Se algum não existe: adicione em Pendências.
-3. Crie task issue de backend antes de começar o frontend se endpoints faltarem.
-4. Ao abrir PR do frontend, referencie este arquivo na descrição.
+1. Adicione a secao neste arquivo com status `em desenvolvimento`.
+2. Liste os endpoints necessarios. Se algum nao existe: adicione em Pendencias.
+3. Crie task issue de backend antes de comecar o frontend se endpoints faltarem.
+4. Ao abrir PR do frontend, referencie este arquivo na descricao.
 
 ### Adicionando endpoint no backend
 
 1. Adicione o endpoint na tabela inversa.
-2. Verifique Pendências — se este endpoint estava lá, atualize o status e notifique.
+2. Verifique Pendencias - se este endpoint estava la, atualize o status e notifique.
 3. Atualize `docs/V2_API_CONTRACT.md` com o contrato completo.
 
 ### Alterando ou removendo endpoint existente
 
-1. Consulte a tabela inversa — identifique todas as rotas afetadas.
+1. Consulte a tabela inversa - identifique todas as rotas afetadas.
 2. Classifique como `risk:contract-sensitive` na task issue.
-3. Coordinate com o owner do frontend antes de fazer merge.
+3. Coordene com o owner do frontend antes de fazer merge.
 4. Atualize este documento e `docs/V2_API_CONTRACT.md` no mesmo PR.
 
 ---
 
-_Última atualização: 2026-04-09 — Sessão 34 | issue #34_
+_Ultima atualizacao: 2026-04-09 - issue #42_

--- a/docs/V2_PHASE2_WEB_SLICE.md
+++ b/docs/V2_PHASE2_WEB_SLICE.md
@@ -4,7 +4,7 @@
 
 Entregar o primeiro fluxo web funcional da V2 em `apps/web`, consumindo apenas a API read-only em `apps/api`.
 
-Escopo fechado desta fase:
+Escopo fechado original desta fase:
 - `/`
 - `/empresas`
 - `/empresas/[cd_cvm]`
@@ -12,6 +12,9 @@ Escopo fechado desta fase:
 O objetivo nao e cobrir o sitemap inteiro. O objetivo e fechar o primeiro fluxo util:
 
 `Home -> Empresas -> Empresa`
+
+Pacote aditivo entregue depois do slice inicial:
+- `/comparar`
 
 ## Stack
 
@@ -54,6 +57,14 @@ O objetivo nao e cobrir o sitemap inteiro. O objetivo e fechar o primeiro fluxo 
 - aba `demonstracoes`
 - `stmt` em URL com `DRE`, `BPA`, `BPP`, `DFC`
 
+### `/comparar`
+
+- selecao de empresas por busca e sugestoes rapidas
+- deep-link publico por `ids` e `anos`
+- periodo anual resolvido por interseccao entre empresas
+- tabela comparativa de KPIs com base de referencia na primeira empresa
+- fallback explicito para ausencia de anos em comum, erro parcial e IDs invalidos
+
 ## Query params publicos
 
 ### Hub
@@ -73,6 +84,14 @@ Defaults:
 - `aba=visao-geral`
 - `stmt=DRE`
 - `anos`: 3 anos mais recentes, ou menos se a empresa tiver menos historico
+
+### Compare
+
+- `/comparar?ids=9512,1179&anos=2023,2024`
+
+Defaults:
+- `ids`: vazio ate o usuario montar a selecao inicial
+- `anos`: interseccao mais recente resolvida pelo frontend quando a URL nao informar um periodo valido
 
 ## Comandos locais
 
@@ -106,7 +125,6 @@ npm run test:e2e
 
 ## O que fica para a proxima fase
 
-- `/comparar`
 - `/setores`
 - `/kpis`
 - `/macro`


### PR DESCRIPTION
## Issue

Closes #42

## Resumo

- promove `docs/INTERFACE_MAP.md` para tratar PG-04 `/comparar` como rota `live`
- alinha `docs/V2_PHASE2_WEB_SLICE.md` para registrar `/comparar` como pacote aditivo entregue apos o slice inicial

## Paralelismo

- lane da task: `lane:ops-quality`
- worktree usada: `.claude/worktrees/ops-quality/42-pg04-docs-comparar-live/`
- esta e a unica PR oficial da task: `sim`
- risco da task: `risk:safe`
- write-set principal:
  - `docs/INTERFACE_MAP.md`
  - `docs/V2_PHASE2_WEB_SLICE.md`
- coordenacao com outras tasks/PRs:
  - child task da #40 (`lane:frontend`)

## Compatibilidade

- politica aplicada: `n/a`
- impacto em API, schema ou docs publicos:
  - atualiza apenas documentacao de status/escopo; sem mudanca de contrato HTTP

## Validacao

- [x] validacoes executadas e registradas abaixo

```text
git diff --check
```

## Checklist

- [x] a branch segue `task/<issue-number>-<slug>`
- [x] a issue vinculada esta atualizada com checklist/status/evidencias
- [x] a issue vinculada registra owner atual, lane oficial, workspace da task, write-set esperado e `risk:*`
- [x] docs relevantes foram atualizados quando necessario
- [x] lane da task e worktree oficial foram registradas nesta PR
- [x] se a task for `risk:shared` ou `risk:contract-sensitive`, a PR abriu em draft
- [x] se a task for `risk:contract-sensitive`, a compatibilidade foi revisada e documentada
- [x] PR em draft apenas enquanto o trabalho ou as validacoes ainda estiverem incompletos
- [ ] checks obrigatorios verdes ou helper de conclusao acionado para aguardar
- [ ] pronto para `squash merge` em `master` quando os checks estiverem verdes
- [ ] nao considerar a task concluida ate confirmar merge, issue fechada e branch remota removida quando aplicavel