### PR TITLE
fix(api): filtrar anos ITR em /years e anos_disponiveis

### DIFF
--- a/apps/api/tests/conftest.py
+++ b/apps/api/tests/conftest.py
@@ -153,6 +153,10 @@ def _seed_database(settings: AppSettings) -> None:
         {"COMPANY_NAME": "SABESP", "CD_CVM": 11223, "STATEMENT_TYPE": "BPP", "REPORT_YEAR": 2024, "PERIOD_LABEL": "2024", "LINE_ID_BASE": "sabesp-bpp", "CD_CONTA": "2", "DS_CONTA": "Passivo Total", "STANDARD_NAME": "Passivo Total", "QA_CONFLICT": 0, "VL_CONTA": 320.0},
         {"COMPANY_NAME": "SABESP", "CD_CVM": 11223, "STATEMENT_TYPE": "DRE", "REPORT_YEAR": 2024, "PERIOD_LABEL": "2024", "LINE_ID_BASE": "sabesp-dre", "CD_CONTA": "3.01", "DS_CONTA": "Receita Liquida", "STANDARD_NAME": "Receita", "QA_CONFLICT": 0, "VL_CONTA": 420.0},
         {"COMPANY_NAME": "SABESP", "CD_CVM": 11223, "STATEMENT_TYPE": "DFC", "REPORT_YEAR": 2024, "PERIOD_LABEL": "2024", "LINE_ID_BASE": "sabesp-dfc", "CD_CONTA": "6.01", "DS_CONTA": "Fluxo Operacional", "STANDARD_NAME": "FCO", "QA_CONFLICT": 0, "VL_CONTA": 90.0},
+        # ITR-only rows: REPORT_YEAR=2025 but PERIOD_LABEL is quarterly (nao anual).
+        # Esses registros sao intencional: testam que /years exclui anos sem DFP completo.
+        {"COMPANY_NAME": "PETROBRAS", "CD_CVM": 9512, "STATEMENT_TYPE": "BPA", "REPORT_YEAR": 2025, "PERIOD_LABEL": "1Q25", "LINE_ID_BASE": "itr-bpa-1", "CD_CONTA": "1", "DS_CONTA": "Ativo Total", "STANDARD_NAME": "Ativo Total", "QA_CONFLICT": 0, "VL_CONTA": 1250.0},
+        {"COMPANY_NAME": "PETROBRAS", "CD_CVM": 9512, "STATEMENT_TYPE": "DRE", "REPORT_YEAR": 2025, "PERIOD_LABEL": "1Q25", "LINE_ID_BASE": "itr-dre-1", "CD_CONTA": "3.01", "DS_CONTA": "Receita Liquida", "STANDARD_NAME": "Receita", "QA_CONFLICT": 0, "VL_CONTA": 280.0},
     ]
 
     with engine.begin() as conn:

--- a/apps/api/tests/test_api_contract.py
+++ b/apps/api/tests/test_api_contract.py
@@ -405,3 +405,23 @@ def test_company_summary_blocks_have_non_empty_titles(client: TestClient):
     assert response.status_code == 200
     for block in response.json()["blocks"]:
         assert isinstance(block["title"], str) and len(block["title"]) > 0
+
+
+# ── Regressao: /years exclui anos com apenas dados trimestrais ITR ─────────────
+# A seed do banco inclui linhas ITR para PETROBRAS (REPORT_YEAR=2025,
+# PERIOD_LABEL="1Q25"). Sem o filtro PERIOD_LABEL = CAST(REPORT_YEAR AS TEXT)
+# o endpoint retornaria [2023, 2024, 2025] e o Comparar usaria referenceYear=2025,
+# cujas colunas nao existem no KPI bundle (KPI engine so usa dados anuais).
+# Isso causaria todos os valores "-" na tabela de comparacao.
+
+def test_company_years_excludes_itr_only_years(client: TestClient):
+    """Garante que /years retorna apenas anos com DFP (PERIOD_LABEL == ano)."""
+    response = client.get("/companies/9512/years")
+
+    assert response.status_code == 200
+    years = response.json()
+    # 2025 so tem ITR (PERIOD_LABEL="1Q25") no seed — nao deve aparecer
+    assert 2025 not in years
+    # anos com DFP completo devem permanecer
+    assert 2023 in years
+    assert 2024 in years

--- a/src/query_layer.py
+++ b/src/query_layer.py
@@ -148,6 +148,13 @@ class CVMQueryLayer:
         return pd.read_sql(sql, self.engine).reset_index(drop=True)
 
     def get_company_years_map(self, cd_cvms: list[int]) -> dict[int, tuple[int, ...]]:
+        """Retorna mapa cd_cvm → anos com dados anuais completos (DFP).
+
+        Filtra por PERIOD_LABEL = REPORT_YEAR (ex: '2024') para excluir anos que
+        possuam apenas dados trimestrais ITR, mantendo consistencia com
+        get_available_years e garantindo que anos_disponiveis reflita apenas
+        periodos computaveis pelo KPI engine.
+        """
         if not cd_cvms:
             return {}
 
@@ -159,6 +166,7 @@ class CVMQueryLayer:
             SELECT CD_CVM, REPORT_YEAR
             FROM financial_reports
             WHERE CD_CVM IN ({placeholders})
+              AND PERIOD_LABEL = CAST(REPORT_YEAR AS TEXT)
             GROUP BY CD_CVM, REPORT_YEAR
             ORDER BY CD_CVM, REPORT_YEAR
             """
@@ -225,11 +233,21 @@ class CVMQueryLayer:
         return row.iloc[0].to_dict()
 
     def get_available_years(self, cd_cvm: int) -> list[int]:
+        """Retorna os anos com dados anuais completos (DFP) para a empresa.
+
+        Filtra por PERIOD_LABEL = REPORT_YEAR (ex: '2024') para excluir anos que
+        possuam apenas dados trimestrais ITR (ex: '1Q24', '3Q25').  Isso garante
+        que o endpoint /years retorne somente anos computaveis pelo KPI engine,
+        que tambem filtra por periodo anual.  Sem esse filtro, companias com ITR
+        mais recente do que o ultimo DFP publicado causariam referenceYear sem
+        dados no Comparar, exibindo '-' em todas as celulas.
+        """
         sql = text(
             """
             SELECT DISTINCT REPORT_YEAR
             FROM financial_reports
             WHERE CD_CVM = :cd_cvm
+              AND PERIOD_LABEL = CAST(REPORT_YEAR AS TEXT)
             ORDER BY REPORT_YEAR
             """
         )


### PR DESCRIPTION
## Resumo

- Corrige o bug onde a página Comparar exibia "-" em todos os valores de KPI
- Root cause: `get_available_years` e `get_company_years_map` incluíam anos com apenas dados trimestrais ITR (`PERIOD_LABEL='1Q25'`), mas o KPI engine só usa dados anuais (`PERIOD_LABEL = REPORT_YEAR`)
- Quando `referenceYear = 2025` (apenas ITR), as colunas `"2025"` não existiam no bundle → `coerceFiniteNumber` retornava null para todas as células
- Fix: adiciona `AND PERIOD_LABEL = CAST(REPORT_YEAR AS TEXT)` nas duas queries
- Adiciona seed ITR + teste de regressão `test_company_years_excludes_itr_only_years`

## Fluxo do bug (antes do fix)

```
BD: PETROBRAS tem ITR 2025 (PERIOD_LABEL="1Q25", REPORT_YEAR=2025)
/years → [2023, 2024, 2025]           ← incluía ITR
selectedYears.slice(-3) → [2024, 2025] → referenceYear = 2025
fetchCompanyKpis(..., [2024, 2025])
  → KPI engine filtra PERIOD_LABEL="2025" → 0 rows para 2025
  → bundle.annual.rows não tem coluna "2025"
row?.["2025"] = undefined → null → todos os valores "-"
```

## Após o fix

```
/years → [2023, 2024]                 ← apenas DFP anuais
referenceYear = 2024
bundle.annual.rows tem coluna "2024"  ← valores corretos
```

## Test plan

- [ ] `pytest apps/api/tests/ -q` — 40 testes verdes incluindo `test_company_years_excludes_itr_only_years`
- [ ] `pytest tests/ -q` — 127 testes verdes
- [ ] Verificar manualmente a página `/comparar?ids=9512,4170` exibe valores numéricos

## Compatibilidade

- Mudança aditiva de comportamento: `/years` e `anos_disponiveis` passam a retornar um subconjunto mais preciso de anos
- Não é breaking change: contrato da API não muda, apenas os valores retornados tornam-se mais corretos
- Downgrade seguro: remover o filtro restaura o comportamento anterior

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)