### PR TITLE
[Task #48] Add Excel export endpoints to V2 API

### DIFF
--- a/apps/api/app/dependencies.py
+++ b/apps/api/app/dependencies.py
@@ -105,6 +105,40 @@ def years_dependency(years: str | None = Query(default=None)) -> list[int]:
     return parse_years_csv(years)
 
 
+def parse_company_ids_csv(
+    raw_ids: str | None,
+    *,
+    minimum: int = 1,
+) -> list[int]:
+    if raw_ids is None:
+        raise InvalidRequestError("O parametro 'ids' e obrigatorio.")
+
+    tokens = [token.strip() for token in str(raw_ids).split(",")]
+    if not tokens or any(not token for token in tokens):
+        raise InvalidRequestError("O parametro 'ids' deve ser uma lista CSV de inteiros.")
+
+    parsed: list[int] = []
+    seen: set[int] = set()
+    for token in tokens:
+        try:
+            company_id = int(token)
+        except ValueError as exc:
+            raise InvalidRequestError("O parametro 'ids' aceita apenas inteiros.") from exc
+        if company_id in seen:
+            raise InvalidRequestError("O parametro 'ids' nao pode conter valores duplicados.")
+        seen.add(company_id)
+        parsed.append(company_id)
+
+    if len(parsed) < minimum:
+        raise InvalidRequestError(f"O parametro 'ids' exige ao menos {minimum} empresa(s).")
+
+    return parsed
+
+
+def company_ids_dependency(ids: str | None = Query(default=None)) -> list[int]:
+    return parse_company_ids_csv(ids, minimum=2)
+
+
 def statement_dependency(stmt: str = Query(..., description="Tipo de demonstracao.")) -> str:
     normalized = str(stmt).strip().upper()
     if normalized not in SUPPORTED_STATEMENTS:

--- a/apps/api/app/routes/companies.py
+++ b/apps/api/app/routes/companies.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends, Query, Request
+from fastapi.responses import Response
 
 from apps.api.app.dependencies import (
+    InvalidRequestError,
     NotFoundError,
+    company_ids_dependency,
     coerce_company,
     ensure_api_ready,
     get_read_service,
@@ -67,6 +70,32 @@ def get_company_filters(
 
 
 @router.get(
+    "/companies/export/excel-batch",
+    summary="Retorna um arquivo ZIP com um workbook Excel por empresa selecionada.",
+)
+def export_companies_excel_batch(
+    request: Request,
+    ids: list[int] = Depends(company_ids_dependency),
+    service: CVMReadService = Depends(get_read_service),
+) -> Response:
+    ensure_api_ready(get_settings(request))
+    for cd_cvm in ids:
+        coerce_company(cd_cvm, service)
+    try:
+        filename, payload = service.build_companies_excel_batch_export(ids)
+    except ValueError as exc:
+        raise InvalidRequestError(str(exc)) from exc
+
+    return Response(
+        content=payload,
+        media_type="application/zip",
+        headers={
+            "Content-Disposition": f'attachment; filename="{filename}"',
+        },
+    )
+
+
+@router.get(
     "/companies/{cd_cvm}",
     response_model=CompanyInfoPayload,
     summary="Retorna os metadados principais de uma empresa.",
@@ -81,6 +110,31 @@ def get_company(
     if info is None:
         raise NotFoundError(f"Empresa {cd_cvm} nao encontrada.")
     return present_company_info(info)
+
+
+@router.get(
+    "/companies/{cd_cvm}/export/excel",
+    summary="Retorna o workbook Excel completo da empresa para download.",
+)
+def export_company_excel(
+    cd_cvm: int,
+    request: Request,
+    service: CVMReadService = Depends(get_read_service),
+) -> Response:
+    ensure_api_ready(get_settings(request))
+    coerce_company(cd_cvm, service)
+    try:
+        filename, payload = service.build_company_excel_export(cd_cvm)
+    except ValueError as exc:
+        raise InvalidRequestError(str(exc)) from exc
+
+    return Response(
+        content=payload,
+        media_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        headers={
+            "Content-Disposition": f'attachment; filename="{filename}"',
+        },
+    )
 
 
 @router.get(

--- a/apps/api/tests/test_api_contract.py
+++ b/apps/api/tests/test_api_contract.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+import io
+import zipfile
 from pathlib import Path
 
+import openpyxl
 from fastapi.testclient import TestClient
 
 from apps.api.app.main import create_app
@@ -142,6 +145,84 @@ def test_company_years_returns_empty_list_when_company_has_no_reports(client: Te
 
     assert response.status_code == 200
     assert response.json() == []
+
+
+def test_company_excel_export_returns_binary_workbook(client: TestClient):
+    response = client.get("/companies/9512/export/excel")
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith(
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    )
+    assert 'filename="PETR4_' in response.headers["content-disposition"]
+
+    workbook = openpyxl.load_workbook(io.BytesIO(response.content))
+    assert workbook.sheetnames[:4] == ["CAPA", "GERAL", "KPIs", "DRE"]
+
+
+def test_company_excel_export_uses_all_available_years(client: TestClient):
+    response = client.get("/companies/9512/export/excel")
+
+    assert response.status_code == 200
+    workbook = openpyxl.load_workbook(io.BytesIO(response.content))
+    dre = workbook["DRE"]
+
+    assert dre["E1"].value == "2023"
+    assert dre["F1"].value == "2024"
+
+
+def test_company_excel_export_returns_404_for_unknown_company(client: TestClient):
+    response = client.get("/companies/999999/export/excel")
+
+    assert response.status_code == 404
+    assert response.json()["error"]["code"] == "not_found"
+
+
+def test_company_excel_export_returns_422_when_company_has_no_exportable_years(client: TestClient):
+    response = client.get("/companies/77889/export/excel")
+
+    assert response.status_code == 422
+    assert response.json()["error"]["code"] == "invalid_request"
+
+
+def test_company_excel_batch_export_returns_zip_with_one_workbook_per_company(client: TestClient):
+    response = client.get("/companies/export/excel-batch", params={"ids": "9512,4170"})
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("application/zip")
+    assert 'filename="comparar_excel_lote.zip"' in response.headers["content-disposition"]
+
+    with zipfile.ZipFile(io.BytesIO(response.content)) as archive:
+        names = sorted(archive.namelist())
+        assert len(names) == 2
+        assert names[0].startswith("PETR4_")
+        assert names[1].startswith("VALE3_")
+        assert names[0].endswith(".xlsx")
+        assert names[1].endswith(".xlsx")
+
+        workbook = openpyxl.load_workbook(io.BytesIO(archive.read(names[0])))
+        assert "CAPA" in workbook.sheetnames
+
+
+def test_company_excel_batch_export_rejects_duplicate_ids(client: TestClient):
+    response = client.get("/companies/export/excel-batch", params={"ids": "9512,9512"})
+
+    assert response.status_code == 422
+    assert response.json()["error"]["code"] == "invalid_request"
+
+
+def test_company_excel_batch_export_rejects_single_company(client: TestClient):
+    response = client.get("/companies/export/excel-batch", params={"ids": "9512"})
+
+    assert response.status_code == 422
+    assert response.json()["error"]["code"] == "invalid_request"
+
+
+def test_company_excel_batch_export_returns_404_for_unknown_company(client: TestClient):
+    response = client.get("/companies/export/excel-batch", params={"ids": "9512,999999"})
+
+    assert response.status_code == 404
+    assert response.json()["error"]["code"] == "not_found"
 
 
 def test_company_statement_returns_matrix(client: TestClient):

--- a/docs/V2_API_CONTRACT.md
+++ b/docs/V2_API_CONTRACT.md
@@ -126,6 +126,46 @@ Resposta exemplo:
 }
 ```
 
+### `GET /companies/{cd_cvm}/export/excel`
+
+Uso:
+- retorna o workbook Excel completo da empresa como binario `.xlsx`
+- usa sempre todos os anos disponiveis da empresa na base
+- preserva o contrato atual do exportador da V1: `CAPA`, `GERAL`, `KPIs`,
+  `DRE`, `BPA`, `BPP`, `DFC`, opcionais `DVA` e `DMPL` quando houver dados, e
+  `METADADOS`
+
+Headers principais:
+- `Content-Type: application/vnd.openxmlformats-officedocument.spreadsheetml.sheet`
+- `Content-Disposition: attachment; filename="<ticker-ou-cvm>_<yyyymmdd>.xlsx"`
+
+Regras do endpoint:
+- `404` para empresa inexistente
+- `422` para empresa existente sem anos exportaveis
+- o workbook e gerado no dominio Python (`src/read_service.py` +
+  `src/excel_exporter.py`), nao na camada HTTP
+
+### `GET /companies/export/excel-batch?ids=`
+
+Parametros:
+- `ids`: obrigatorio; CSV de inteiros sem duplicatas, com ao menos 2 empresas,
+  ex. `9512,4170`
+
+Uso:
+- retorna um `.zip` com um workbook `.xlsx` por empresa selecionada
+- existe para o fluxo `/comparar`, sem inventar um workbook combinado novo
+
+Headers principais:
+- `Content-Type: application/zip`
+- `Content-Disposition: attachment; filename="comparar_excel_lote.zip"`
+
+Regras do endpoint:
+- `404` se alguma empresa informada nao existir
+- `422` para `ids` invalido, duplicado ou com menos de 2 empresas
+- cada arquivo interno reutiliza o mesmo contrato do endpoint individual por
+  empresa
+- a ordem dos arquivos no lote segue a ordem dos `ids` recebidos
+
 ### `GET /companies/{cd_cvm}/years`
 
 Resposta:
@@ -305,10 +345,12 @@ Resposta exemplo:
 ## Regras de interface
 
 - respostas usam DTOs estabilizados em `src/contracts.py`
-- nao expor `DataFrame` bruto
+- nao expor `DataFrame` bruto nos endpoints JSON
 - `404` para empresa inexistente
 - `422` para validacao HTTP e parametros invalidos
 - `503` para falha operacional ou banco indisponivel
+- endpoints binarios devem usar `Content-Disposition: attachment` com nome de
+  arquivo estavel
 
 Payload padrao de erro:
 

--- a/src/excel_exporter.py
+++ b/src/excel_exporter.py
@@ -71,6 +71,26 @@ _KPI_CATEGORY_ORDER = [
 ]
 
 
+def build_excel_file_stem(
+    company_info: dict,
+    *,
+    generated_at: datetime | None = None,
+) -> str:
+    """Retorna o file stem padrao usado pelos downloads de Excel."""
+    timestamp = generated_at or datetime.now()
+    ticker = company_info.get("ticker_b3") or f"cvm{company_info.get('cd_cvm', '')}"
+    safe_ticker = str(ticker).replace(" ", "_").replace("/", "-")
+    return f"{safe_ticker}_{timestamp.strftime('%Y%m%d')}"
+
+
+def build_excel_filename(
+    company_info: dict,
+    *,
+    generated_at: datetime | None = None,
+) -> str:
+    return f"{build_excel_file_stem(company_info, generated_at=generated_at)}.xlsx"
+
+
 class ExcelExporter:
     """Gera workbook Excel profissional para uma empresa CVM.
 

--- a/src/read_service.py
+++ b/src/read_service.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import io
+import zipfile
 from typing import Any
 
 import pandas as pd
@@ -24,10 +26,13 @@ from src.contracts import (
 )
 from src.statement_summary import build_general_summary_blocks
 from src.db import build_engine
+from src.excel_exporter import ExcelExporter, build_excel_filename
 from src.kpi_engine import compute_all_kpis, compute_quarterly_kpis
 from src.query_layer import CVMQueryLayer
 from src.sector_taxonomy import canonical_sector_name, sector_slugify
 from src.settings import AppSettings, get_settings
+
+EXPORT_STATEMENT_TYPES = ("DRE", "BPA", "BPP", "DFC", "DVA", "DMPL")
 
 
 def _parse_years(raw_years: str | None) -> tuple[int, ...]:
@@ -226,6 +231,61 @@ class CVMReadService:
             years=tuple(sorted(int(y) for y in years)),
             blocks=blocks,
         )
+
+    def build_company_excel_export(self, cd_cvm: int) -> tuple[str, bytes]:
+        company_info = self.get_company_info_dict(cd_cvm)
+        if not company_info:
+            raise ValueError(f"Empresa {cd_cvm} nao encontrada.")
+
+        years = self.get_available_years(cd_cvm)
+        if not years:
+            raise ValueError(f"Empresa {cd_cvm} nao possui anos disponiveis para exportacao.")
+
+        statements = {
+            stmt_type: self.get_statement_dataframe(cd_cvm, years, stmt_type)
+            for stmt_type in EXPORT_STATEMENT_TYPES
+        }
+        exportable_statements = {
+            stmt_type: df
+            for stmt_type, df in statements.items()
+            if df is not None and not df.empty
+        }
+        extra_sheets = [
+            stmt_type
+            for stmt_type in ("DVA", "DMPL")
+            if stmt_type in exportable_statements
+        ]
+        kpis_df = self.get_kpi_bundle(cd_cvm, years).quarterly_dataframe()
+
+        exporter = ExcelExporter(
+            company_info=company_info,
+            statements=exportable_statements,
+            kpis_df=kpis_df,
+            extra_sheets=extra_sheets,
+        )
+        return build_excel_filename(company_info), exporter.export()
+
+    def build_companies_excel_batch_export(self, cd_cvms: list[int]) -> tuple[str, bytes]:
+        if len(cd_cvms) < 2:
+            raise ValueError("O lote de exportacao exige ao menos 2 empresas.")
+
+        seen: set[int] = set()
+        unique_ids: list[int] = []
+        for cd_cvm in cd_cvms:
+            normalized = int(cd_cvm)
+            if normalized in seen:
+                raise ValueError("O lote de exportacao nao aceita empresas duplicadas.")
+            seen.add(normalized)
+            unique_ids.append(normalized)
+
+        buffer = io.BytesIO()
+        with zipfile.ZipFile(buffer, mode="w", compression=zipfile.ZIP_DEFLATED) as archive:
+            for cd_cvm in unique_ids:
+                filename, payload = self.build_company_excel_export(cd_cvm)
+                archive.writestr(filename, payload)
+
+        buffer.seek(0)
+        return "comparar_excel_lote.zip", buffer.read()
 
     def get_health_snapshot(
         self,

--- a/tests/test_excel_exporter.py
+++ b/tests/test_excel_exporter.py
@@ -1,5 +1,6 @@
 import io
 import sys
+from datetime import datetime
 from pathlib import Path
 
 import openpyxl
@@ -7,7 +8,7 @@ import pandas as pd
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
-from src.excel_exporter import ExcelExporter
+from src.excel_exporter import ExcelExporter, build_excel_filename
 
 
 def _statement(rows: list[dict[str, object]]) -> pd.DataFrame:
@@ -139,3 +140,24 @@ def test_excel_exporter_geral_sheet_preserves_periods_and_expanded_rows():
 
     assert dre["A1"].value == "CD_CONTA"
     assert dre["B2"].value == "Receita"
+
+
+def test_build_excel_filename_uses_ticker_and_export_date():
+    filename = build_excel_filename(
+        _sample_company(),
+        generated_at=datetime(2026, 4, 9, 14, 30),
+    )
+
+    assert filename == "EXMP3_20260409.xlsx"
+
+
+def test_build_excel_filename_falls_back_to_cvm_code_without_ticker():
+    filename = build_excel_filename(
+        {
+            **_sample_company(),
+            "ticker_b3": None,
+        },
+        generated_at=datetime(2026, 4, 9, 14, 30),
+    )
+
+    assert filename == "cvm1234_20260409.xlsx"


### PR DESCRIPTION
## Resumo
- adiciona endpoint binario para workbook Excel por empresa na API V2
- adiciona endpoint de lote em `.zip` para o fluxo de comparacao multipla
- reaproveita `src/read_service.py` + `src/excel_exporter.py` como fonte de verdade do artefato

## Compatibilidade
- additive-only
- nenhum endpoint JSON existente foi alterado ou removido
- novos endpoints binarios:
  - `GET /companies/{cd_cvm}/export/excel`
  - `GET /companies/export/excel-batch?ids=`
- o contrato binario foi documentado em `docs/V2_API_CONTRACT.md`

## Validacao
- `pytest apps/api/tests -q`
- `pytest tests/test_excel_exporter.py -q`

Closes #48