### PR TITLE
feat(api): CORS configuravel via ALLOWED_ORIGINS env var (#50)

### DIFF
--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import os
 import time
 
 from fastapi import FastAPI, Request
@@ -35,9 +36,12 @@ def create_app(
     app.state.settings = resolved_settings
     app.state.read_service = resolved_service
 
+    _raw_origins = os.getenv("ALLOWED_ORIGINS", "http://localhost:3000")
+    _allowed_origins = [origin.strip() for origin in _raw_origins.split(",") if origin.strip()]
+
     app.add_middleware(
         CORSMiddleware,
-        allow_origins=["http://localhost:3000"],
+        allow_origins=_allowed_origins,
         allow_credentials=True,
         allow_methods=["*"],
         allow_headers=["*"],

--- a/apps/api/tests/test_api_contract.py
+++ b/apps/api/tests/test_api_contract.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
 from fastapi.testclient import TestClient
 
 from apps.api.app.main import create_app
@@ -425,3 +426,38 @@ def test_company_years_excludes_itr_only_years(client: TestClient):
     # anos com DFP completo devem permanecer
     assert 2023 in years
     assert 2024 in years
+
+
+# ── CORS: ALLOWED_ORIGINS configuravel via env var ─────────────────────────────
+
+
+def test_cors_default_allows_localhost(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    """Sem ALLOWED_ORIGINS, apenas http://localhost:3000 e aceito."""
+    monkeypatch.delenv("ALLOWED_ORIGINS", raising=False)
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{tmp_path / 'cors_test.db'}")
+    settings = build_settings()
+    test_app = create_app(settings=settings)
+    with TestClient(test_app) as c:
+        response = c.options(
+            "/health",
+            headers={"Origin": "http://localhost:3000", "Access-Control-Request-Method": "GET"},
+        )
+    assert response.status_code == 200
+    assert response.headers.get("access-control-allow-origin") == "http://localhost:3000"
+
+
+def test_cors_env_var_allows_multiple_origins(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    """ALLOWED_ORIGINS com varios valores separados por virgula — todos aceitos."""
+    monkeypatch.setenv("ALLOWED_ORIGINS", "https://app.vercel.app,https://staging.vercel.app")
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{tmp_path / 'cors_multi.db'}")
+    settings = build_settings()
+    test_app = create_app(settings=settings)
+    with TestClient(test_app) as c:
+        for origin in ("https://app.vercel.app", "https://staging.vercel.app"):
+            resp = c.options(
+                "/health",
+                headers={"Origin": origin, "Access-Control-Request-Method": "GET"},
+            )
+            assert resp.headers.get("access-control-allow-origin") == origin, (
+                f"Origem {origin} nao foi aceita pelo CORS"
+            )


### PR DESCRIPTION
## O que muda

Substitui a lista hardcoded `["http://localhost:3000"]` por leitura da
env var `ALLOWED_ORIGINS` no middleware CORS do FastAPI.

```python
_raw_origins = os.getenv("ALLOWED_ORIGINS", "http://localhost:3000")
_allowed_origins = [origin.strip() for origin in _raw_origins.split(",") if origin.strip()]
```

## Por que

Pré-requisito para o deploy na nuvem: o frontend em Vercel precisará
estar na lista de origens aceitas pela API na Railway.
Sem essa mudança nenhum browser aceita as respostas da API.

## Compatibilidade

- `ALLOWED_ORIGINS` não configurada → comportamento idêntico ao atual
- `ALLOWED_ORIGINS=http://localhost:3000` → mesmo que antes
- `ALLOWED_ORIGINS=https://app.vercel.app,https://staging.vercel.app` → múltiplas origens

## Testes

- `test_cors_default_allows_localhost` — sem env var, localhost:3000 é aceito
- `test_cors_env_var_allows_multiple_origins` — multi-origem via env var
- 169 testes verdes (40 API + 127 root + 2 novos CORS)

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)