### PR TITLE
chore(guardrails): registrar railway.toml e vercel.json no allowlist (#55)

### DIFF
--- a/.github/guardrails/path-policy.json
+++ b/.github/guardrails/path-policy.json
@@ -23,7 +23,9 @@
       "CONTRIBUTING.md",
       "README.md",
       "COMO_RODAR.md",
-      "pytest.ini"
+      "pytest.ini",
+      "railway.toml",
+      "vercel.json"
     ]
   },
   "criticalGroups": [


### PR DESCRIPTION
## O que muda

Adiciona `railway.toml` e `vercel.json` ao `laneAllowlists.ops-quality`
em `.github/guardrails/path-policy.json`.

## Por que

O plano de deploy em nuvem cria esses arquivos na raiz do repo.
Sem essa entrada o CI rejeita qualquer PR que os inclua com
"arquivo nao esta classificado em path-policy.json".

## Impacto

Zero impacto em produção — apenas amplia o que a lane ops-quality
pode criar/modificar na raiz do repositório.

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)