### PR TITLE
chore(guardrails): config/** no allowlist ops-quality (#61)

### DIFF
--- a/.github/guardrails/path-policy.json
+++ b/.github/guardrails/path-policy.json
@@ -18,6 +18,7 @@
       ".github/**",
       "docs/**",
       "scripts/**",
+      "config/**",
       "AGENTS.md",
       "CLAUDE.md",
       "CONTRIBUTING.md",


### PR DESCRIPTION
## O que muda

Adiciona `config/**` ao `laneAllowlists.ops-quality` em `path-policy.json`.

## Por que

O plano de deploy move `canonical_accounts.csv` para `config/` (tracked no git).
Sem essa entrada o CI rejeita a PR de migracao com "nao esta classificado".

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)