### PR TITLE
feat(web): vercel.json para deploy Next.js na Vercel (#64)

### DIFF
--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -1,0 +1,6 @@
+{
+  "framework": "nextjs",
+  "installCommand": "npm ci",
+  "buildCommand": "npm run build",
+  "outputDirectory": ".next"
+}


### PR DESCRIPTION
## O que muda

Cria `apps/web/vercel.json` com configuracao padrao para deploy Next.js:

```json
{
  "framework": "nextjs",
  "installCommand": "npm ci",
  "buildCommand": "npm run build",
  "outputDirectory": ".next"
}
```

## Configuracao no dashboard Vercel

- Root Directory: `apps/web`
- Env var: `API_BASE_URL=https://<railway>.up.railway.app`

`API_BASE_URL` ja e lido por `apps/web/lib/api.ts` — nada muda no codigo.

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)