### PR TITLE
feat(ci): deploy automatico Railway + Vercel ao merge (#71)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,3 +105,19 @@ jobs:
 
       - name: Run web build
         run: npm run build
+
+  deploy-api:
+    needs: [test-python]
+    if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Railway deploy
+        run: curl -fsSL -X POST "${{ secrets.RAILWAY_DEPLOY_HOOK }}"
+
+  deploy-web:
+    needs: [test-web]
+    if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Vercel deploy
+        run: curl -fsSL -X POST "${{ secrets.VERCEL_DEPLOY_HOOK }}"


### PR DESCRIPTION
## O que muda

Adiciona 2 jobs ao `ci.yml` que disparam webhooks de deploy ao merge no master:

```yaml
deploy-api:
  needs: [test-python]
  if: github.ref == 'refs/heads/master' && github.event_name == 'push'
  run: curl -X POST "${{ secrets.RAILWAY_DEPLOY_HOOK }}"

deploy-web:
  needs: [test-web]
  if: github.ref == 'refs/heads/master' && github.event_name == 'push'
  run: curl -X POST "${{ secrets.VERCEL_DEPLOY_HOOK }}"
```

## Configuracao manual necessaria

**GitHub Settings → Secrets:**
- `RAILWAY_DEPLOY_HOOK` → gerado no painel Railway: Settings → Deploy → Deploy Hooks
- `VERCEL_DEPLOY_HOOK` → gerado no Vercel: Settings → Git → Deploy Hooks

## Comportamento em PRs/task branches

Os jobs `deploy-api` e `deploy-web` so rodam em `push` para `master` (condicao `if:`).
Em PRs e branches `task/**` eles sao ignorados — CI continua exatamente igual.

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)