### PR TITLE
docs: definir runtime remoto inicial da V2 (#9)

### DIFF
--- a/docs/STUDENT_PACK_PLAN.md
+++ b/docs/STUDENT_PACK_PLAN.md
@@ -26,6 +26,13 @@ Atualizacao em 2026-04-07:
 - direcao escolhida: `Next.js` + `FastAPI/Uvicorn` + `PostgreSQL` + `Ubuntu Linux`;
 - `Nginx` fica opcional no inicio e entra apenas quando houver self-hosting ou necessidade real de reverse proxy.
 
+Atualizacao em 2026-04-09:
+- o primeiro runtime remoto de aprendizado da V2 fica congelado no ADR
+  [0004 - Primeiro runtime remoto: Railway + Vercel](./decisions/0004-first-remote-runtime-railway-vercel.md);
+- o deploy inicial continua limitado ao slice `/`, `/empresas` e
+  `/empresas/[cd_cvm]`;
+- `/comparar` continua fora do gate remoto desta wave.
+
 ## 1.1 Aprendizado por construcao
 
 Este projeto nao e apenas uma migracao de stack. Ele tambem funciona como trilha pratica de aprendizado em:
@@ -41,7 +48,8 @@ Por isso, o Student Pack entra em duas frentes ao mesmo tempo:
 Sequencia adotada:
 1. `docs/decisions/0002-student-pack-v2-stack.md` congela a stack recomendada.
 2. `docs/WEBAPP_TRANSFORMATION_PLAN.md` define as fases, o primeiro slice tecnico e os objetivos de aprendizado.
-3. `docs/STUDENT_PACK_PLAN.md` registra como os beneficios do Pack apoiam essa trajetoria.
+3. `docs/decisions/0004-first-remote-runtime-railway-vercel.md` fixa o primeiro runtime remoto do ciclo atual.
+4. `docs/STUDENT_PACK_PLAN.md` registra como os beneficios do Pack apoiam essa trajetoria.
 
 ---
 
@@ -70,7 +78,7 @@ Atualizacao operacional em 2026-04-09:
 | JetBrains Student | Produtividade | em avaliacao | alta | melhora navegacao e manutencao do codigo Python | manutencao do scraper, DB e testes | conta elegivel e IDE instalada | baixo; depende de preferencia de IDE | avaliar junto com Copilot | [GitHub Pack](https://education.github.com/pack), [JetBrains Education](https://www.jetbrains.com/community/education/) |
 | GitHub Codespaces | Produtividade | em avaliacao | alta | ajuda a ter ambiente reproduzivel e trabalho remoto | onboarding, testes, estudo da V2 | repo configuravel para dev container depois | custo de tempo para configurar ambiente | avaliar no ciclo, sem bloquear entregas | [GitHub Pack](https://education.github.com/pack), [Codespaces](https://github.com/features/codespaces) |
 | Frontend Masters | Aprendizado aplicado | em avaliacao | imediata | acelera a transicao para fullstack sem travar a V1 | fase de descoberta da V2 | trilha inicial definida e rotina de estudo | custo principal e tempo | usar como base para decidir stack da V2 | [GitHub Pack](https://education.github.com/pack), [Frontend Masters](https://frontendmasters.com/) |
-| Trilha cloud compativel com V2 | Infra/deploy | em avaliacao | imediata | permite ambiente remoto de aprendizado e futura V2 | deploy de testes e primeira fatia da V2 | escolher parceiro ativo do Pack no momento da ativacao | risco medio se a escolha vier cedo demais | escolher 1 ambiente de aprendizado sem fixar a arquitetura final | [GitHub Pack](https://education.github.com/pack) |
+| Trilha cloud compativel com V2 | Infra/deploy | em avaliacao | imediata | permite ambiente remoto de aprendizado e futura V2 | deploy de testes e primeira fatia da V2 | decisao do runtime remoto registrada no ADR 0004 | risco medio se a escolha vier cedo demais | usar `Railway + Vercel` como ambiente de aprendizado desta wave | [GitHub Pack](https://education.github.com/pack) |
 | Sentry | Observabilidade | em avaliacao | imediata | captura erros e reduz diagnostico manual em ambiente remoto | primeiro runtime remoto da V2 ou servico exposto | projeto remoto minimo e DSN configurado | baixo; exige decidir primeiro runtime remoto | integrar no primeiro runtime que ficar online | [GitHub Pack](https://education.github.com/pack), [Sentry](https://sentry.io/) |
 | Codecov | Qualidade | ativado | imediata | torna cobertura visivel e cria guardrail antes da V2 | CI/testes do repo atual | workflow de CI com pytest | baixo; upload externo segue dependente do servico | manter ativo no CI atual e revalidar a visibilidade no servico externo | [GitHub Pack](https://education.github.com/pack), [Codecov](https://about.codecov.io/) |
 | Doppler ou similar | Secrets/operacao | nao priorizado agora | depois | melhora gestao de segredos quando houver multiplos ambientes | deploy cloud e ambientes remotos | multiplos secrets reais e ambientes persistentes | custo operacional desnecessario cedo demais | avaliar apenas depois do primeiro runtime remoto estavel | [GitHub Pack](https://education.github.com/pack), [Doppler](https://www.doppler.com/) |
@@ -89,7 +97,7 @@ Preencher esta tabela conforme os beneficios forem ativados ou descartados.
 | JetBrains Student | `@jadaojoao` | em avaliacao | GitHub Pack + JetBrains Education | revalidar no momento da ativacao | decidir IDE principal | validar se entrara no fluxo diario |
 | GitHub Codespaces | `@jadaojoao` | em avaliacao | GitHub Pack + Codespaces | revalidar no momento da ativacao | definir ambiente de dev remoto | avaliar depois da documentacao do ambiente |
 | Frontend Masters | `@jadaojoao` | em avaliacao | GitHub Pack + Frontend Masters | revalidar no momento da ativacao | definir trilha inicial | concluir trilha inicial e registrar aprendizados |
-| Trilha cloud compativel com V2 | `@jadaojoao` | em avaliacao | GitHub Pack + parceiro cloud ativo | revalidar no momento da ativacao | escolher parceiro | decidir 1 ambiente de aprendizado |
+| Trilha cloud compativel com V2 | `@jadaojoao` | em avaliacao | GitHub Pack + parceiro cloud ativo | revalidar no momento da ativacao | ADR 0004 publicado | executar onboarding e validacao remota em `Railway + Vercel` |
 | Sentry | `@jadaojoao` | em avaliacao | GitHub Pack + Sentry | revalidar no momento da ativacao | existir runtime remoto | integrar no primeiro runtime remoto |
 | Codecov | `@jadaojoao` | ativado | GitHub Pack + Codecov | revalidar no momento da ativacao | CI atual ja integrado na task #8 | manter upload nao bloqueante e confirmar visibilidade no servico |
 | Doppler ou similar | `@jadaojoao` | nao priorizado agora | GitHub Pack + parceiro ativo | revalidar no momento da ativacao | multiplos ambientes remotos | revisitar apos primeiro deploy estavel |
@@ -104,8 +112,8 @@ Preencher esta tabela conforme os beneficios forem ativados ou descartados.
   existir contexto de dev container ou onboarding remoto.
 - Frontend Masters: confirmar o resgate do beneficio, concluir a trilha
   inicial e publicar os aprendizados na issue `#7`.
-- Trilha cloud compativel com V2: registrar a escolha do ambiente de
-  aprendizado na task `#9` antes de qualquer ativacao mais profunda.
+- Trilha cloud compativel com V2: seguir o ADR `0004`, publicar API na
+  `Railway`, publicar web na `Vercel` e registrar o smoke remoto na task `#14`.
 - Sentry: criar o projeto apenas depois do primeiro runtime remoto definido e
   validar a integracao pela task `#13`.
 - Codecov: manter a integracao do CI ativa, confirmar a visibilidade do

--- a/docs/WEBAPP_TRANSFORMATION_PLAN.md
+++ b/docs/WEBAPP_TRANSFORMATION_PLAN.md
@@ -3,6 +3,7 @@
 > Documento de execucao para a transformacao do projeto atual em uma web app mais proxima de producao.
 > Escopo deste documento: roadmap, refinamento por fases e objetivo de aprendizado.
 > Base arquitetural: [0002 - Stack recomendada para a V2 com GitHub Student Developer Pack](./decisions/0002-student-pack-v2-stack.md).
+> Runtime remoto do ciclo atual: [0004 - Primeiro runtime remoto: Railway + Vercel](./decisions/0004-first-remote-runtime-railway-vercel.md).
 
 ---
 
@@ -104,6 +105,12 @@ Meta de entrega:
 - validar conectividade remota, erros basicos e operacao de leitura fora do ambiente local;
 - manter a V1 local como fonte operacional em paralelo.
 
+Decisao operacional do ciclo atual:
+- API e banco alvo na `Railway`;
+- web em `Vercel`;
+- contrato minimo entre camadas usando `ALLOWED_ORIGINS` na API e
+  `API_BASE_URL` na web.
+
 Meta de aprendizado:
 - aprender deploy gerenciado por camada, sem assumir self-hosting cedo demais;
 - aprender configuracao de ambiente, secrets e conexoes remotas;
@@ -138,7 +145,8 @@ Saida esperada:
 1. Fechar a Fase 1 com validacao PostgreSQL real.
 2. Consolidar o primeiro slice `Home -> Empresas -> Empresa` em `apps/web`.
 3. Testar o slice local completo antes de qualquer deploy remoto.
-4. Publicar o primeiro slice em deploy gerenciado, sem introduzir `Nginx` cedo demais.
+4. Publicar a API na `Railway` e a web na `Vercel`, sem introduzir `Nginx`
+   cedo demais.
 5. Integrar observabilidade e qualidade antes de expandir escopo funcional.
 
 ---
@@ -147,6 +155,6 @@ Saida esperada:
 
 - nao muda a stack atual da V1;
 - nao substitui a documentacao detalhada da Fase 1 em `docs/V2_PHASE1_BACKEND.md`;
-- nao define provedor especifico de deploy;
+- nao substitui o ADR `0004`, que fixa o primeiro runtime remoto do ciclo;
 - nao introduz endpoints de escrita;
 - nao substitui o ADR 0002, que continua sendo a decisao arquitetural principal.

--- a/docs/decisions/0004-first-remote-runtime-railway-vercel.md
+++ b/docs/decisions/0004-first-remote-runtime-railway-vercel.md
@@ -1,0 +1,79 @@
+# 0004 - Primeiro runtime remoto: Railway + Vercel
+
+- **Status:** accepted
+- **Data:** 2026-04-09
+- **Autor:** human+ai
+
+## Contexto
+
+Depois do ADR 0002, o projeto ainda precisava fixar qual seria o primeiro
+ambiente remoto de aprendizado da V2.
+
+Essa decisao precisava respeitar quatro restricoes praticas:
+- manter a V1 operacional sem migracao forcada;
+- publicar frontend e API em camadas separadas;
+- reduzir a carga operacional da primeira wave remota;
+- usar o estado real do repositorio, que ja possui artefatos de deploy para
+  `apps/api` e `apps/web`.
+
+## Decisao
+
+O primeiro runtime remoto do ciclo atual fica definido como:
+- **API e banco alvo:** `Railway`
+- **Web app:** `Vercel`
+
+O escopo remoto inicial continua limitado a:
+- `/`
+- `/empresas`
+- `/empresas/[cd_cvm]`
+
+O pacote `/comparar` fica fora do gate desta wave.
+
+## Racional
+
+### 1. Aderencia ao estado atual do repo
+
+O repositorio ja possui:
+- `apps/api/Dockerfile`
+- `apps/api/requirements-prod.txt`
+- `railway.toml`
+- `apps/web/vercel.json`
+
+Escolher `Railway + Vercel` reaproveita trabalho ja entregue e reduz retrabalho
+na primeira publicacao.
+
+### 2. Separacao limpa por camada
+
+`Railway` atende bem ao runtime Python da API e ao uso de `PostgreSQL` como
+alvo remoto. `Vercel` atende bem ao `Next.js` do slice web atual. A dupla
+preserva a arquitetura `frontend + API + Postgres` sem forcar um host unico ou
+reverse proxy cedo demais.
+
+### 3. Menor atrito operacional na primeira wave
+
+O objetivo desta fase nao e montar infraestrutura completa. O objetivo e obter
+um runtime remoto funcional, com healthcheck, CORS configurado, variaveis de
+ambiente claras e um caminho simples para observabilidade.
+
+### 4. Compatibilidade com a proxima etapa
+
+Essa decisao deixa explicito o contrato operacional minimo entre as camadas:
+- a API remota deve aceitar o dominio publicado da web em `ALLOWED_ORIGINS`;
+- a web remota deve apontar para a API publicada via `API_BASE_URL`;
+- a validacao remota deve usar `PostgreSQL` real, nao fallback local;
+- a integracao de Sentry entra depois, com escopo inicial `API first`.
+
+## Consequencias
+
+- `Railway + Vercel` vira o ambiente de aprendizado oficial desta wave.
+- A V1 continua como fallback local e operacional durante toda a validacao
+  remota.
+- `Nginx` permanece opcional e fora do primeiro deploy.
+- O fechamento da task de deploy remoto exige URLs publicas, smoke funcional do
+  slice web e evidencia de conexao com `PostgreSQL`.
+
+## Referencias
+
+- [0002 - Stack recomendada para a V2 com GitHub Student Developer Pack](./0002-student-pack-v2-stack.md)
+- [docs/STUDENT_PACK_PLAN.md](../STUDENT_PACK_PLAN.md)
+- [docs/WEBAPP_TRANSFORMATION_PLAN.md](../WEBAPP_TRANSFORMATION_PLAN.md)


### PR DESCRIPTION
## O que muda

- adiciona o ADR `0004` para fixar `Railway + Vercel` como primeiro runtime remoto da V2
- atualiza `docs/STUDENT_PACK_PLAN.md` para apontar a trilha cloud para o ADR `0004`
- atualiza `docs/WEBAPP_TRANSFORMATION_PLAN.md` para refletir a decisao operacional da wave remota

## Validacao

- `git diff --check`

Closes #9