### PR TITLE
feat(api): integrar Sentry na API FastAPI (#75)

### DIFF
--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -4,10 +4,13 @@ import logging
 import os
 import time
 
+import sentry_sdk
 from fastapi import FastAPI, Request
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
+from sentry_sdk.integrations.fastapi import FastApiIntegration
+from sentry_sdk.integrations.starlette import StarletteIntegration
 
 from apps.api.app.dependencies import ApiError, ServiceUnavailableError, serialize_error
 from apps.api.app.presenters import ErrorResponsePayload
@@ -20,11 +23,29 @@ from src.settings import AppSettings, get_settings as get_shared_settings
 log = logging.getLogger("cvm.api")
 
 
+def _init_sentry() -> None:
+    dsn = os.getenv("SENTRY_DSN", "")
+    if not dsn:
+        return
+    sentry_sdk.init(
+        dsn=dsn,
+        environment=os.getenv("SENTRY_ENVIRONMENT", "production"),
+        integrations=[
+            StarletteIntegration(transaction_style="endpoint"),
+            FastApiIntegration(transaction_style="endpoint"),
+        ],
+        traces_sample_rate=0.1,
+        send_default_pii=False,
+    )
+    log.info("sentry_initialized environment=%s", os.getenv("SENTRY_ENVIRONMENT", "production"))
+
+
 def create_app(
     *,
     settings: AppSettings | None = None,
     read_service: CVMReadService | None = None,
 ) -> FastAPI:
+    _init_sentry()
     resolved_settings = settings or get_shared_settings()
     resolved_service = read_service or CVMReadService(settings=resolved_settings)
 

--- a/apps/api/requirements-prod.txt
+++ b/apps/api/requirements-prod.txt
@@ -9,3 +9,4 @@ xlsxwriter>=3.1
 requests>=2.31
 fastapi>=0.115
 uvicorn[standard]>=0.32
+sentry-sdk[fastapi]>=2.0

--- a/apps/api/requirements.txt
+++ b/apps/api/requirements.txt
@@ -1,3 +1,4 @@
 -r ../../requirements.txt
 fastapi>=0.115
 uvicorn[standard]>=0.32
+sentry-sdk[fastapi]>=2.0

--- a/apps/api/tests/test_api_contract.py
+++ b/apps/api/tests/test_api_contract.py
@@ -542,3 +542,32 @@ def test_cors_env_var_allows_multiple_origins(monkeypatch: pytest.MonkeyPatch, t
             assert resp.headers.get("access-control-allow-origin") == origin, (
                 f"Origem {origin} nao foi aceita pelo CORS"
             )
+
+
+# ── Sentry: inicializacao condicional via SENTRY_DSN ──────────────────────────
+
+
+def test_sentry_skipped_when_dsn_is_absent(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    """Sem SENTRY_DSN, o Sentry nao deve ser inicializado."""
+    import sentry_sdk
+
+    monkeypatch.delenv("SENTRY_DSN", raising=False)
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{tmp_path / 'sentry_off.db'}")
+    settings = build_settings()
+    create_app(settings=settings)
+    assert sentry_sdk.get_client().dsn is None
+
+
+def test_sentry_initialized_when_dsn_is_present(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    """Com SENTRY_DSN valido, o Sentry deve ser inicializado com o environment correto."""
+    import sentry_sdk
+
+    fake_dsn = "https://pub@o0.ingest.sentry.io/0"
+    monkeypatch.setenv("SENTRY_DSN", fake_dsn)
+    monkeypatch.setenv("SENTRY_ENVIRONMENT", "staging")
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{tmp_path / 'sentry_on.db'}")
+    settings = build_settings()
+    create_app(settings=settings)
+    client = sentry_sdk.get_client()
+    assert client.dsn == fake_dsn
+    assert client.options["environment"] == "staging"


### PR DESCRIPTION
## Contexto

Child task da #13 (ops-quality, `status:blocked`). Instrumenta a API FastAPI
com Sentry para captura de exceções não tratadas em produção na Railway.

## O que mudou

- `apps/api/app/main.py` — `_init_sentry()` inicializa o SDK apenas quando
  `SENTRY_DSN` está presente; usa `StarletteIntegration` + `FastApiIntegration`
  com `transaction_style="endpoint"`
- `apps/api/requirements.txt` — adiciona `sentry-sdk[fastapi]>=2.0`
- `apps/api/requirements-prod.txt` — idem para o runtime de produção
- `apps/api/tests/test_api_contract.py` — 2 testes: sem DSN → SDK inativo;
  com DSN → SDK inicializado com environment correto

## Variáveis de ambiente suportadas

| Variável | Obrigatória | Default |
|---|---|---|
| `SENTRY_DSN` | Sim (sem ela, Sentry fica desativado) | — |
| `SENTRY_ENVIRONMENT` | Não | `production` |

## Evidência

```
52 passed, 1 warning in 4.18s
```

## Critério de consumo (para lane:ops-quality)

A entrega está consumível quando:
- `SENTRY_DSN` + `SENTRY_ENVIRONMENT` configurados no Railway
- Evento de teste disparado via `sentry_sdk.capture_message("smoke")` em um
  worker temporário (ver runbook abaixo)

## Runbook de verificação do evento de teste

```python
# Rodar uma vez no ambiente Railway após configurar SENTRY_DSN:
import sentry_sdk
sentry_sdk.init(dsn=SENTRY_DSN, environment=SENTRY_ENVIRONMENT)
sentry_sdk.capture_message("smoke: sentry integration live")
sentry_sdk.flush()
```

Verificar em Issues > "smoke: sentry integration live" no projeto Sentry.

## Risco

`risk:shared` — toca `apps/api/` + `tests/`; não altera contratos públicos.

## Checklist

- [x] `SENTRY_DSN` ausente → SDK não inicializado (testado)
- [x] `SENTRY_DSN` presente → SDK ativo com environment correto (testado)
- [x] 52/52 testes passando
- [x] `requirements.txt` e `requirements-prod.txt` atualizados
- [x] Runbook de verificação incluído

Closes #75