### PR TITLE
[Task #81] Add sector endpoints to the V2 API

### DIFF
--- a/apps/api/app/dependencies.py
+++ b/apps/api/app/dependencies.py
@@ -105,6 +105,25 @@ def years_dependency(years: str | None = Query(default=None)) -> list[int]:
     return parse_years_csv(years)
 
 
+def optional_year_dependency(year: str | None = Query(default=None)) -> int | None:
+    if year is None:
+        return None
+
+    token = str(year).strip()
+    if not token:
+        raise InvalidRequestError("O parametro 'year' aceita um unico inteiro positivo.")
+
+    try:
+        parsed = int(token)
+    except ValueError as exc:
+        raise InvalidRequestError("O parametro 'year' aceita um unico inteiro positivo.") from exc
+
+    if parsed <= 0:
+        raise InvalidRequestError("O parametro 'year' aceita um unico inteiro positivo.")
+
+    return parsed
+
+
 def parse_company_ids_csv(
     raw_ids: str | None,
     *,

--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -16,6 +16,7 @@ from apps.api.app.dependencies import ApiError, ServiceUnavailableError, seriali
 from apps.api.app.presenters import ErrorResponsePayload
 from apps.api.app.routes.companies import router as companies_router
 from apps.api.app.routes.health import router as health_router
+from apps.api.app.routes.sectors import router as sectors_router
 from apps.api.app.routes.status import router as status_router
 from src.read_service import CVMReadService
 from src.settings import AppSettings, get_settings as get_shared_settings
@@ -115,6 +116,7 @@ def create_app(
 
     app.include_router(health_router)
     app.include_router(companies_router)
+    app.include_router(sectors_router)
     app.include_router(status_router)
     return app
 

--- a/apps/api/app/presenters.py
+++ b/apps/api/app/presenters.py
@@ -13,6 +13,8 @@ from src.contracts import (
     HealthSnapshot,
     KPIBundle,
     RefreshStatusDTO,
+    SectorDetailDTO,
+    SectorDirectoryDTO,
     StatementMatrix,
     StatementSummaryDTO,
 )
@@ -97,6 +99,50 @@ class CompanySectorFilterPayload(BaseModel):
 
 class CompanyFiltersPayload(BaseModel):
     sectors: list[CompanySectorFilterPayload]
+
+
+class SectorSnapshotPayload(BaseModel):
+    roe: float | None = None
+    mg_ebit: float | None = None
+    mg_liq: float | None = None
+
+
+class SectorDirectoryItemPayload(BaseModel):
+    sector_name: str
+    sector_slug: str
+    company_count: int
+    latest_year: int | None = None
+    snapshot: SectorSnapshotPayload
+
+
+class SectorDirectoryPayload(BaseModel):
+    items: list[SectorDirectoryItemPayload]
+
+
+class SectorYearOverviewPayload(BaseModel):
+    year: int
+    roe: float | None = None
+    mg_ebit: float | None = None
+    mg_liq: float | None = None
+
+
+class SectorCompanyMetricPayload(BaseModel):
+    cd_cvm: int
+    company_name: str
+    ticker_b3: str | None = None
+    roe: float | None = None
+    mg_ebit: float | None = None
+    mg_liq: float | None = None
+
+
+class SectorDetailPayload(BaseModel):
+    sector_name: str
+    sector_slug: str
+    company_count: int
+    available_years: list[int]
+    selected_year: int
+    yearly_overview: list[SectorYearOverviewPayload]
+    companies: list[SectorCompanyMetricPayload]
 
 
 class TabularDataPayload(BaseModel):
@@ -221,6 +267,14 @@ def present_company_directory_page(dto: CompanyDirectoryPage) -> CompanyDirector
 
 def present_company_filters(dto: CompanyFiltersDTO) -> CompanyFiltersPayload:
     return CompanyFiltersPayload(**dto.to_dict())
+
+
+def present_sector_directory(dto: SectorDirectoryDTO) -> SectorDirectoryPayload:
+    return SectorDirectoryPayload(**dto.to_dict())
+
+
+def present_sector_detail(dto: SectorDetailDTO) -> SectorDetailPayload:
+    return SectorDetailPayload(**dto.to_dict())
 
 
 def present_company_info(dto: CompanyInfoDTO) -> CompanyInfoPayload:

--- a/apps/api/app/routes/sectors.py
+++ b/apps/api/app/routes/sectors.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Request
+
+from apps.api.app.dependencies import (
+    InvalidRequestError,
+    NotFoundError,
+    ensure_api_ready,
+    get_read_service,
+    get_settings,
+    optional_year_dependency,
+)
+from apps.api.app.presenters import (
+    SectorDetailPayload,
+    SectorDirectoryPayload,
+    present_sector_detail,
+    present_sector_directory,
+)
+from src.read_service import CVMReadService
+
+router = APIRouter(tags=["sectors"])
+
+
+@router.get(
+    "/sectors",
+    response_model=SectorDirectoryPayload,
+    summary="Retorna o hub setorial com snapshot agregado por setor.",
+)
+def list_sectors(
+    request: Request,
+    service: CVMReadService = Depends(get_read_service),
+) -> SectorDirectoryPayload:
+    ensure_api_ready(get_settings(request))
+    return present_sector_directory(service.list_sectors())
+
+
+@router.get(
+    "/sectors/{sector_slug}",
+    response_model=SectorDetailPayload,
+    summary="Retorna o detalhe de um setor com serie anual e empresas do ano selecionado.",
+)
+def get_sector_detail(
+    sector_slug: str,
+    request: Request,
+    year: int | None = Depends(optional_year_dependency),
+    service: CVMReadService = Depends(get_read_service),
+) -> SectorDetailPayload:
+    ensure_api_ready(get_settings(request))
+    try:
+        detail = service.get_sector_detail(sector_slug=sector_slug, year=year)
+    except ValueError as exc:
+        raise InvalidRequestError(str(exc)) from exc
+
+    if detail is None:
+        raise NotFoundError(f"Setor '{sector_slug}' nao encontrado.")
+
+    return present_sector_detail(detail)

--- a/apps/api/tests/test_api_contract.py
+++ b/apps/api/tests/test_api_contract.py
@@ -106,6 +106,112 @@ def test_companies_filters_returns_canonical_sector_options(client: TestClient):
     ]
 
 
+def test_sectors_returns_directory_with_latest_year_and_snapshot(client: TestClient):
+    response = client.get("/sectors")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert [item["sector_name"] for item in payload["items"]] == [
+        "Energia",
+        "Materiais Basicos",
+        "Saneamento",
+    ]
+    energia = payload["items"][0]
+    assert energia["sector_slug"] == "energia"
+    assert energia["company_count"] == 1
+    assert energia["latest_year"] == 2024
+    assert energia["snapshot"]["roe"] == pytest.approx(180.0 / 380.0)
+    assert energia["snapshot"]["mg_ebit"] == pytest.approx(240.0 / 1100.0)
+    assert energia["snapshot"]["mg_liq"] == pytest.approx(180.0 / 1100.0)
+
+
+def test_sectors_directory_keeps_null_snapshot_metrics_when_accounts_are_partial(client: TestClient):
+    response = client.get("/sectors")
+
+    assert response.status_code == 200
+    payload = response.json()
+    materiais = next(item for item in payload["items"] if item["sector_slug"] == "materiais-basicos")
+    assert materiais["latest_year"] == 2024
+    assert materiais["snapshot"] == {"roe": None, "mg_ebit": None, "mg_liq": None}
+
+
+def test_sector_detail_returns_default_latest_year_and_yearly_overview(client: TestClient):
+    response = client.get("/sectors/energia")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["sector_name"] == "Energia"
+    assert payload["sector_slug"] == "energia"
+    assert payload["company_count"] == 1
+    assert payload["available_years"] == [2023, 2024]
+    assert payload["selected_year"] == 2024
+    assert payload["yearly_overview"] == [
+        {
+            "year": 2023,
+            "roe": pytest.approx(150.0 / 300.0),
+            "mg_ebit": pytest.approx(200.0 / 1000.0),
+            "mg_liq": pytest.approx(150.0 / 1000.0),
+        },
+        {
+            "year": 2024,
+            "roe": pytest.approx(180.0 / 380.0),
+            "mg_ebit": pytest.approx(240.0 / 1100.0),
+            "mg_liq": pytest.approx(180.0 / 1100.0),
+        },
+    ]
+    assert payload["companies"] == [
+        {
+            "cd_cvm": 9512,
+            "company_name": "PETROBRAS",
+            "ticker_b3": "PETR4",
+            "roe": pytest.approx(180.0 / 380.0),
+            "mg_ebit": pytest.approx(240.0 / 1100.0),
+            "mg_liq": pytest.approx(180.0 / 1100.0),
+        }
+    ]
+
+
+def test_sector_detail_respects_explicit_year(client: TestClient):
+    response = client.get("/sectors/energia", params={"year": "2023"})
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["selected_year"] == 2023
+    assert payload["companies"][0]["roe"] == pytest.approx(150.0 / 300.0)
+
+
+def test_sector_detail_keeps_company_row_with_null_metrics_when_accounts_are_partial(client: TestClient):
+    response = client.get("/sectors/saneamento")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["selected_year"] == 2024
+    assert payload["companies"] == [
+        {
+            "cd_cvm": 11223,
+            "company_name": "SABESP",
+            "ticker_b3": "SBSP3",
+            "roe": None,
+            "mg_ebit": None,
+            "mg_liq": None,
+        }
+    ]
+
+
+def test_sector_detail_returns_404_for_unknown_slug(client: TestClient):
+    response = client.get("/sectors/setor-inexistente")
+
+    assert response.status_code == 404
+    assert response.json()["error"]["code"] == "not_found"
+
+
+def test_sector_detail_returns_422_for_year_outside_available_range(client: TestClient):
+    response = client.get("/sectors/energia", params={"year": "1990"})
+
+    assert response.status_code == 422
+    assert response.json()["error"]["code"] == "invalid_request"
+
+
 def test_company_detail_returns_metadata(client: TestClient):
     response = client.get("/companies/9512")
 

--- a/docs/V2_API_CONTRACT.md
+++ b/docs/V2_API_CONTRACT.md
@@ -104,6 +104,80 @@ Resposta exemplo:
 }
 ```
 
+### `GET /sectors`
+
+Uso:
+- retorna o hub setorial da V2 com snapshot agregado por setor
+- a ordenacao padrao e `company_count DESC`, depois `sector_name ASC`
+
+Resposta exemplo:
+
+```json
+{
+  "items": [
+    {
+      "sector_name": "Energia",
+      "sector_slug": "energia",
+      "company_count": 12,
+      "latest_year": 2024,
+      "snapshot": {
+        "roe": 0.18,
+        "mg_ebit": 0.21,
+        "mg_liq": 0.14
+      }
+    }
+  ]
+}
+```
+
+Regras do endpoint:
+- `snapshot` usa os KPIs agregados do `latest_year` do setor
+- `roe`, `mg_ebit` e `mg_liq` podem ser `null` quando o setor nao tiver contas suficientes
+- o item do setor continua valido mesmo quando o snapshot vier parcial ou nulo
+
+### `GET /sectors/{slug}?year=`
+
+Parametros:
+- `year`: opcional; inteiro positivo. Quando omitido, o backend usa o ano mais recente disponivel do setor
+
+Resposta exemplo:
+
+```json
+{
+  "sector_name": "Energia",
+  "sector_slug": "energia",
+  "company_count": 12,
+  "available_years": [2023, 2024],
+  "selected_year": 2024,
+  "yearly_overview": [
+    {
+      "year": 2023,
+      "roe": 0.16,
+      "mg_ebit": 0.19,
+      "mg_liq": 0.13
+    }
+  ],
+  "companies": [
+    {
+      "cd_cvm": 9512,
+      "company_name": "PETROBRAS",
+      "ticker_b3": "PETR4",
+      "roe": 0.47,
+      "mg_ebit": 0.21,
+      "mg_liq": 0.16
+    }
+  ]
+}
+```
+
+Regras do endpoint:
+- `404` para `slug` inexistente
+- `422` para `year` invalido ou fora dos anos disponiveis do setor
+- `available_years` sai em ordem crescente
+- `companies` sai ordenado por `roe DESC`, depois `company_name ASC`, com `null` no fim
+- `yearly_overview` agrega `roe`, `mg_ebit` e `mg_liq` por ano, ignorando valores ausentes
+- `companies` do `selected_year` continuam presentes mesmo quando as metricas do ano vierem `null`
+
 ### `GET /companies/{cd_cvm}`
 
 DTO de saida:

--- a/src/contracts.py
+++ b/src/contracts.py
@@ -227,6 +227,84 @@ class CompanyFiltersDTO:
 
 
 @dataclass(frozen=True)
+class SectorSnapshotDTO:
+    roe: float | None
+    mg_ebit: float | None
+    mg_liq: float | None
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class SectorDirectoryItemDTO:
+    sector_name: str
+    sector_slug: str
+    company_count: int
+    latest_year: int | None
+    snapshot: SectorSnapshotDTO
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = asdict(self)
+        payload["snapshot"] = self.snapshot.to_dict()
+        return payload
+
+
+@dataclass(frozen=True)
+class SectorDirectoryDTO:
+    items: tuple[SectorDirectoryItemDTO, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"items": [item.to_dict() for item in self.items]}
+
+
+@dataclass(frozen=True)
+class SectorYearOverviewDTO:
+    year: int
+    roe: float | None
+    mg_ebit: float | None
+    mg_liq: float | None
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class SectorCompanyMetricDTO:
+    cd_cvm: int
+    company_name: str
+    ticker_b3: str | None
+    roe: float | None
+    mg_ebit: float | None
+    mg_liq: float | None
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class SectorDetailDTO:
+    sector_name: str
+    sector_slug: str
+    company_count: int
+    available_years: tuple[int, ...]
+    selected_year: int
+    yearly_overview: tuple[SectorYearOverviewDTO, ...]
+    companies: tuple[SectorCompanyMetricDTO, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "sector_name": self.sector_name,
+            "sector_slug": self.sector_slug,
+            "company_count": self.company_count,
+            "available_years": list(self.available_years),
+            "selected_year": self.selected_year,
+            "yearly_overview": [row.to_dict() for row in self.yearly_overview],
+            "companies": [row.to_dict() for row in self.companies],
+        }
+
+
+@dataclass(frozen=True)
 class StatementMatrix:
     cd_cvm: int
     statement_type: str

--- a/src/query_layer.py
+++ b/src/query_layer.py
@@ -147,6 +147,123 @@ class CVMQueryLayer:
         )
         return pd.read_sql(sql, self.engine).reset_index(drop=True)
 
+    def get_sector_available_years(self, sector_name: str) -> list[int]:
+        sql = text(
+            f"""
+            SELECT DISTINCT fr.REPORT_YEAR
+            FROM financial_reports fr
+            JOIN companies c ON c.cd_cvm = fr.CD_CVM
+            WHERE {_CANONICAL_SECTOR_SQL} = :sector_name
+              AND fr.PERIOD_LABEL = CAST(fr.REPORT_YEAR AS TEXT)
+            ORDER BY fr.REPORT_YEAR
+            """
+        )
+        df = pd.read_sql(sql, self.engine, params={"sector_name": str(sector_name)})
+        return [int(year) for year in df["REPORT_YEAR"].tolist()]
+
+    def get_sector_metric_rows(
+        self,
+        *,
+        sector_name: str | None = None,
+        years: list[int] | None = None,
+    ) -> pd.DataFrame:
+        where_parts = [
+            "fr.PERIOD_LABEL = CAST(fr.REPORT_YEAR AS TEXT)",
+            "fr.QA_CONFLICT = 0",
+            "fr.CD_CONTA IN ('3.01', '3.05', '3.11', '2.03')",
+        ]
+        params: dict[str, object] = {}
+
+        if sector_name:
+            where_parts.append(f"{_CANONICAL_SECTOR_SQL} = :sector_name")
+            params["sector_name"] = str(sector_name)
+
+        normalized_years = sorted({int(year) for year in years or []})
+        if normalized_years:
+            placeholders = ", ".join(f":y{i}" for i in range(len(normalized_years)))
+            where_parts.append(f"fr.REPORT_YEAR IN ({placeholders})")
+            params.update({f"y{i}": year for i, year in enumerate(normalized_years)})
+
+        sql = text(
+            f"""
+            SELECT
+                c.cd_cvm,
+                c.company_name,
+                c.ticker_b3,
+                {_CANONICAL_SECTOR_SQL} AS sector_name,
+                fr.REPORT_YEAR,
+                fr.CD_CONTA,
+                SUM(fr.VL_CONTA) AS account_value
+            FROM financial_reports fr
+            JOIN companies c ON c.cd_cvm = fr.CD_CVM
+            WHERE {' AND '.join(where_parts)}
+            GROUP BY
+                c.cd_cvm,
+                c.company_name,
+                c.ticker_b3,
+                {_CANONICAL_SECTOR_SQL},
+                fr.REPORT_YEAR,
+                fr.CD_CONTA
+            """
+        )
+        df = pd.read_sql(sql, self.engine, params=params)
+        if df.empty:
+            return pd.DataFrame(
+                columns=[
+                    "cd_cvm",
+                    "company_name",
+                    "ticker_b3",
+                    "sector_name",
+                    "report_year",
+                    "roe",
+                    "mg_ebit",
+                    "mg_liq",
+                ]
+            )
+
+        pivot = df.pivot_table(
+            index=["cd_cvm", "company_name", "ticker_b3", "sector_name", "REPORT_YEAR"],
+            columns="CD_CONTA",
+            values="account_value",
+            aggfunc="first",
+        ).reset_index()
+        pivot.columns.name = None
+        pivot = pivot.rename(
+            columns={
+                "REPORT_YEAR": "report_year",
+                "3.01": "receita",
+                "3.05": "ebit",
+                "3.11": "lucro_liq",
+                "2.03": "pl",
+            }
+        )
+
+        for column in ("receita", "ebit", "lucro_liq", "pl"):
+            if column not in pivot.columns:
+                pivot[column] = pd.NA
+
+        receita = pd.to_numeric(pivot["receita"], errors="coerce")
+        ebit = pd.to_numeric(pivot["ebit"], errors="coerce")
+        lucro_liq = pd.to_numeric(pivot["lucro_liq"], errors="coerce")
+        pl = pd.to_numeric(pivot["pl"], errors="coerce")
+
+        pivot["mg_ebit"] = ebit.divide(receita.where(receita != 0))
+        pivot["mg_liq"] = lucro_liq.divide(receita.where(receita != 0))
+        pivot["roe"] = lucro_liq.divide(pl.where(pl != 0))
+
+        return pivot[
+            [
+                "cd_cvm",
+                "company_name",
+                "ticker_b3",
+                "sector_name",
+                "report_year",
+                "roe",
+                "mg_ebit",
+                "mg_liq",
+            ]
+        ].reset_index(drop=True)
+
     def get_company_years_map(self, cd_cvms: list[int]) -> dict[int, tuple[int, ...]]:
         """Retorna mapa cd_cvm → anos com dados anuais completos (DFP).
 

--- a/src/read_service.py
+++ b/src/read_service.py
@@ -19,6 +19,12 @@ from src.contracts import (
     HealthSnapshot,
     KPIBundle,
     RefreshStatusDTO,
+    SectorCompanyMetricDTO,
+    SectorDetailDTO,
+    SectorDirectoryDTO,
+    SectorDirectoryItemDTO,
+    SectorSnapshotDTO,
+    SectorYearOverviewDTO,
     StatementMatrix,
     StatementSummaryDTO,
     SummaryBlockDTO,
@@ -152,6 +158,133 @@ class CVMReadService:
             for _, row in df.iterrows()
         )
         return CompanyFiltersDTO(sectors=sectors)
+
+    def resolve_sector_slug(self, sector_slug: str | None) -> str | None:
+        return self._resolve_sector_slug(sector_slug)
+
+    def list_sectors(self) -> SectorDirectoryDTO:
+        sectors_df = self.query_layer.get_available_company_sectors()
+        companies_df = self.query_layer.get_companies()
+        metric_rows = self.query_layer.get_sector_metric_rows()
+        yearly = self._aggregate_sector_yearly_metrics(metric_rows)
+
+        items: list[SectorDirectoryItemDTO] = []
+        for _, row in sectors_df.iterrows():
+            sector_name = str(row["sector_name"])
+            sector_companies = companies_df[companies_df["sector_name"] == sector_name]
+            available_years = self._extract_years_from_company_rows(sector_companies)
+            latest_year = max(available_years) if available_years else None
+            snapshot_row = None
+            if latest_year is not None and not yearly.empty:
+                filtered = yearly[
+                    (yearly["sector_name"] == sector_name)
+                    & (yearly["year"] == latest_year)
+                ]
+                snapshot_row = filtered.iloc[0] if not filtered.empty else None
+
+            items.append(
+                SectorDirectoryItemDTO(
+                    sector_name=sector_name,
+                    sector_slug=sector_slugify(sector_name),
+                    company_count=int(row["company_count"] or 0),
+                    latest_year=latest_year,
+                    snapshot=SectorSnapshotDTO(
+                        roe=self._coerce_optional_float(snapshot_row["roe"]) if snapshot_row is not None else None,
+                        mg_ebit=self._coerce_optional_float(snapshot_row["mg_ebit"]) if snapshot_row is not None else None,
+                        mg_liq=self._coerce_optional_float(snapshot_row["mg_liq"]) if snapshot_row is not None else None,
+                    ),
+                )
+            )
+
+        items.sort(key=lambda item: (-item.company_count, item.sector_name))
+        return SectorDirectoryDTO(items=tuple(items))
+
+    def get_sector_detail(self, sector_slug: str, year: int | None = None) -> SectorDetailDTO | None:
+        resolved_sector_name = self._resolve_sector_slug(sector_slug)
+        if resolved_sector_name is None:
+            return None
+
+        company_rows, total_items = self.query_layer.get_companies_directory_page(
+            search="",
+            sector_name=resolved_sector_name,
+            page=1,
+            page_size=None,
+        )
+        if company_rows.empty:
+            return None
+
+        years_map = self.query_layer.get_company_years_map(company_rows["cd_cvm"].tolist())
+        company_rows = company_rows.copy()
+        company_rows["anos_disponiveis"] = company_rows["cd_cvm"].map(
+            lambda cd_cvm: years_map.get(int(cd_cvm), ())
+        )
+        available_years = self._extract_years_from_company_rows(company_rows)
+        if not available_years:
+            return None
+
+        if year is None:
+            selected_year = max(available_years)
+        else:
+            selected_year = int(year)
+            if selected_year not in available_years:
+                raise ValueError(
+                    f"O parametro 'year' precisa ser um dos anos disponiveis do setor: {', '.join(str(value) for value in available_years)}."
+                )
+
+        metric_rows = self.query_layer.get_sector_metric_rows(sector_name=resolved_sector_name)
+        yearly = self._aggregate_sector_yearly_metrics(metric_rows)
+        yearly_overview = tuple(
+            SectorYearOverviewDTO(
+                year=int(row["year"]),
+                roe=self._coerce_optional_float(row["roe"]),
+                mg_ebit=self._coerce_optional_float(row["mg_ebit"]),
+                mg_liq=self._coerce_optional_float(row["mg_liq"]),
+            )
+            for _, row in yearly[yearly["sector_name"] == resolved_sector_name]
+            .sort_values("year")
+            .iterrows()
+        )
+
+        company_metrics = metric_rows[metric_rows["report_year"] == selected_year].copy()
+        selected_companies = company_rows[
+            company_rows["anos_disponiveis"].map(lambda years: selected_year in years)
+        ][["cd_cvm", "company_name", "ticker_b3"]].drop_duplicates()
+        selected_companies = selected_companies.merge(
+            company_metrics[
+                ["cd_cvm", "roe", "mg_ebit", "mg_liq"]
+            ],
+            on="cd_cvm",
+            how="left",
+        )
+        selected_companies["ticker_b3"] = selected_companies["ticker_b3"].replace("", None)
+        selected_companies["sort_roe"] = pd.to_numeric(selected_companies["roe"], errors="coerce")
+        selected_companies = selected_companies.sort_values(
+            by=["sort_roe", "company_name"],
+            ascending=[False, True],
+            na_position="last",
+        )
+
+        companies = tuple(
+            SectorCompanyMetricDTO(
+                cd_cvm=int(row["cd_cvm"]),
+                company_name=str(row["company_name"]),
+                ticker_b3=self._clean_optional_text(row.get("ticker_b3")),
+                roe=self._coerce_optional_float(row.get("roe")),
+                mg_ebit=self._coerce_optional_float(row.get("mg_ebit")),
+                mg_liq=self._coerce_optional_float(row.get("mg_liq")),
+            )
+            for _, row in selected_companies.iterrows()
+        )
+
+        return SectorDetailDTO(
+            sector_name=resolved_sector_name,
+            sector_slug=sector_slugify(resolved_sector_name),
+            company_count=int(total_items),
+            available_years=tuple(available_years),
+            selected_year=int(selected_year),
+            yearly_overview=yearly_overview,
+            companies=companies,
+        )
 
     def get_statement_matrix(
         self,
@@ -387,6 +520,34 @@ class CVMReadService:
             if option.sector_slug == normalized_slug:
                 return option.sector_name
         return None
+
+    @staticmethod
+    def _extract_years_from_company_rows(df: pd.DataFrame) -> list[int]:
+        years: set[int] = set()
+        if df is None or df.empty:
+            return []
+        for raw_years in df.get("anos_disponiveis", []):
+            years.update(_parse_years(raw_years))
+        return sorted(years)
+
+    @staticmethod
+    def _aggregate_sector_yearly_metrics(metric_rows: pd.DataFrame) -> pd.DataFrame:
+        if metric_rows is None or metric_rows.empty:
+            return pd.DataFrame(columns=["sector_name", "year", "roe", "mg_ebit", "mg_liq"])
+
+        aggregated = (
+            metric_rows.groupby(["sector_name", "report_year"], dropna=False)[["roe", "mg_ebit", "mg_liq"]]
+            .mean()
+            .reset_index()
+            .rename(columns={"report_year": "year"})
+        )
+        return aggregated
+
+    @staticmethod
+    def _coerce_optional_float(value: Any) -> float | None:
+        if value is None or pd.isna(value):
+            return None
+        return float(value)
 
     @staticmethod
     def _empty_company_page(

--- a/tests/test_read_service.py
+++ b/tests/test_read_service.py
@@ -55,3 +55,100 @@ def test_list_refresh_status_returns_stable_dto_contract(tmp_path):
     assert dto.last_status == "success"
     assert dto.last_rows_inserted == 120
     assert dto.to_dict()["source_scope"] == "local"
+
+
+def _seed_sector_read_service(tmp_path):
+    settings = build_settings(project_root=tmp_path)
+    settings.paths.db_path.parent.mkdir(parents=True, exist_ok=True)
+
+    with sqlite3.connect(str(settings.paths.db_path)) as conn:
+        conn.execute(
+            """
+            CREATE TABLE companies (
+                cd_cvm INTEGER PRIMARY KEY,
+                company_name TEXT NOT NULL,
+                nome_comercial TEXT,
+                cnpj TEXT,
+                setor_cvm TEXT,
+                setor_analitico TEXT,
+                company_type TEXT,
+                ticker_b3 TEXT,
+                is_active INTEGER,
+                updated_at TEXT
+            )
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE financial_reports (
+                COMPANY_NAME TEXT,
+                CD_CVM INTEGER,
+                STATEMENT_TYPE TEXT,
+                REPORT_YEAR INTEGER,
+                PERIOD_LABEL TEXT,
+                LINE_ID_BASE TEXT,
+                CD_CONTA TEXT,
+                DS_CONTA TEXT,
+                STANDARD_NAME TEXT,
+                QA_CONFLICT INTEGER,
+                VL_CONTA REAL
+            )
+            """
+        )
+        conn.executemany(
+            """
+            INSERT INTO companies (
+                cd_cvm, company_name, nome_comercial, cnpj,
+                setor_cvm, setor_analitico, company_type, ticker_b3, is_active, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                (9512, "PETROBRAS", "Petrobras", "33", "Energia", "Energia", "comercial", "PETR4", 1, "2026"),
+                (11223, "SABESP", "Sabesp", "43", "Saneamento", None, "comercial", "SBSP3", 1, "2026"),
+            ],
+        )
+        conn.executemany(
+            """
+            INSERT INTO financial_reports (
+                COMPANY_NAME, CD_CVM, STATEMENT_TYPE, REPORT_YEAR, PERIOD_LABEL,
+                LINE_ID_BASE, CD_CONTA, DS_CONTA, STANDARD_NAME, QA_CONFLICT, VL_CONTA
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                ("PETROBRAS", 9512, "BPP", 2023, "2023", "bpp-1", "2.03", "Patrimonio Liquido", "Patrimonio Liquido", 0, 300.0),
+                ("PETROBRAS", 9512, "DRE", 2023, "2023", "dre-1", "3.01", "Receita", "Receita", 0, 1000.0),
+                ("PETROBRAS", 9512, "DRE", 2023, "2023", "dre-2", "3.05", "EBIT", "EBIT", 0, 200.0),
+                ("PETROBRAS", 9512, "DRE", 2023, "2023", "dre-3", "3.11", "Lucro", "Lucro_Liq", 0, 150.0),
+                ("PETROBRAS", 9512, "BPP", 2024, "2024", "bpp-2", "2.03", "Patrimonio Liquido", "Patrimonio Liquido", 0, 380.0),
+                ("PETROBRAS", 9512, "DRE", 2024, "2024", "dre-4", "3.01", "Receita", "Receita", 0, 1100.0),
+                ("PETROBRAS", 9512, "DRE", 2024, "2024", "dre-5", "3.05", "EBIT", "EBIT", 0, 240.0),
+                ("PETROBRAS", 9512, "DRE", 2024, "2024", "dre-6", "3.11", "Lucro", "Lucro_Liq", 0, 180.0),
+                ("SABESP", 11223, "DRE", 2024, "2024", "dre-7", "3.01", "Receita", "Receita", 0, 420.0),
+            ],
+        )
+        conn.commit()
+
+    return CVMReadService(settings=settings)
+
+
+def test_list_sectors_returns_stable_snapshot_contract(tmp_path):
+    service = _seed_sector_read_service(tmp_path)
+
+    dto = service.list_sectors()
+
+    assert [row.sector_name for row in dto.items] == ["Energia", "Saneamento"]
+    assert dto.items[0].latest_year == 2024
+    assert round(dto.items[0].snapshot.roe or 0.0, 6) == round(180.0 / 380.0, 6)
+    assert dto.items[1].snapshot.roe is None
+
+
+def test_get_sector_detail_defaults_to_latest_year_and_keeps_null_metrics(tmp_path):
+    service = _seed_sector_read_service(tmp_path)
+
+    detail = service.get_sector_detail("saneamento")
+
+    assert detail is not None
+    assert detail.selected_year == 2024
+    assert detail.available_years == (2024,)
+    assert detail.companies[0].company_name == "SABESP"
+    assert detail.companies[0].roe is None


### PR DESCRIPTION
## Resumo
- adiciona `GET /sectors` e `GET /sectors/{slug}` como contratos read-only para o pacote de Setores da V2
- introduz DTOs, presenters e agregacao setorial no dominio Python sem mover regra para a camada HTTP
- amplia a cobertura de API e dominio e documenta o contrato em `docs/V2_API_CONTRACT.md`

## Compatibilidade
- additive-only
- nenhum endpoint existente foi removido ou teve shape quebrado
- os contratos novos sao opt-in e nao alteram o comportamento de `/companies` ou `/comparar`

## Validacao
- `pytest apps/api/tests/test_api_contract.py -q`
- `pytest tests/test_read_service.py -q`
- `pytest apps/api/tests -q`
- `pytest tests -q`
- smoke HTTP real com `uvicorn` em `/sectors` e `/sectors/{slug}`

## Consumo esperado
- a task mae #80 pode sair de `status:blocked` quando o frontend conseguir implementar `/setores` e `/setores/[slug]` consumindo apenas estes dois endpoints

Closes #81