### PR TITLE
fix(ci): tolerate missing deploy hooks on master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,14 +110,28 @@ jobs:
     needs: [test-python]
     if: github.ref == 'refs/heads/master' && github.event_name == 'push'
     runs-on: ubuntu-latest
+    env:
+      RAILWAY_DEPLOY_HOOK: ${{ secrets.RAILWAY_DEPLOY_HOOK }}
     steps:
+      - name: Skip Railway deploy when hook is missing
+        if: env.RAILWAY_DEPLOY_HOOK == ''
+        run: echo "::warning::RAILWAY_DEPLOY_HOOK is not configured; skipping Railway deploy."
+
       - name: Trigger Railway deploy
-        run: curl -fsSL -X POST "${{ secrets.RAILWAY_DEPLOY_HOOK }}"
+        if: env.RAILWAY_DEPLOY_HOOK != ''
+        run: curl -fsSL -X POST "$RAILWAY_DEPLOY_HOOK"
 
   deploy-web:
     needs: [test-web]
     if: github.ref == 'refs/heads/master' && github.event_name == 'push'
     runs-on: ubuntu-latest
+    env:
+      VERCEL_DEPLOY_HOOK: ${{ secrets.VERCEL_DEPLOY_HOOK }}
     steps:
+      - name: Skip Vercel deploy when hook is missing
+        if: env.VERCEL_DEPLOY_HOOK == ''
+        run: echo "::warning::VERCEL_DEPLOY_HOOK is not configured; skipping Vercel deploy."
+
       - name: Trigger Vercel deploy
-        run: curl -fsSL -X POST "${{ secrets.VERCEL_DEPLOY_HOOK }}"
+        if: env.VERCEL_DEPLOY_HOOK != ''
+        run: curl -fsSL -X POST "$VERCEL_DEPLOY_HOOK"


### PR DESCRIPTION
## Contexto

A task #71 ja tinha colocado os jobs de deploy no `CI`, mas os pushes para `master`
estavam falhando quando os hooks ainda nao estavam configurados. O resultado era
`curl -X POST ""` tanto para Railway quanto para Vercel, quebrando a CI de
`master` sem produzir deploy nenhum.

## O que mudou

- move os secrets de hook para `env` no job
- adiciona um passo explicito de `warning` quando `RAILWAY_DEPLOY_HOOK` ou
  `VERCEL_DEPLOY_HOOK` estiverem vazios
- executa `curl` apenas quando o hook correspondente estiver configurado

## Validacao

- `git diff --check`
- parse YAML local com `python` + `yaml.safe_load`

## Risco

`risk:shared` � toca `.github/workflows/ci.yml` e nao altera runtime da app.

Closes #71
