### PR TITLE
[Task #80] Entregar Setores na V2 web com hub e detalhe

### DIFF
--- a/apps/web/app/not-found.tsx
+++ b/apps/web/app/not-found.tsx
@@ -21,7 +21,7 @@ export default function NotFound() {
         <SectionHeading
           title="Esse caminho ainda nao existe nesta fase."
           titleAs="h1"
-          description="O slice atual cobre a home, o diretorio de empresas, a comparacao e o detalhe por companhia. Rotas de setores, KPIs e macro entram nas proximas fases."
+          description="O slice atual cobre a home, o diretorio de empresas, a comparacao, o detalhe por companhia e a leitura por setores. KPIs e macro entram nas proximas fases."
           bodyClassName="mx-auto max-w-2xl"
           descriptionClassName="mx-auto"
         />

--- a/apps/web/app/setores/[slug]/page.tsx
+++ b/apps/web/app/setores/[slug]/page.tsx
@@ -1,0 +1,228 @@
+import Link from "next/link";
+import type { Metadata } from "next";
+import { ChevronRightIcon } from "lucide-react";
+import { notFound } from "next/navigation";
+
+import { SectorCompanyTable } from "@/components/sectors/sector-company-table";
+import { SectorDetailTracker } from "@/components/sectors/sector-detail-tracker";
+import { SectorOverview } from "@/components/sectors/sector-overview";
+import { SectorUrlTabs } from "@/components/sectors/sector-url-tabs";
+import { SectorYearSelector } from "@/components/sectors/sector-year-selector";
+import {
+  InfoChip,
+  PageShell,
+  SectionHeading,
+  SurfaceCard,
+} from "@/components/shared/design-system-recipes";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { buttonVariants } from "@/components/ui/button";
+import { fetchSectorDetail } from "@/lib/api";
+import { formatCompactInteger } from "@/lib/formatters";
+import { getFirstParam } from "@/lib/search-params";
+import { loadSectorDetailPageData } from "@/lib/sectors-page-data";
+import { cn } from "@/lib/utils";
+
+type SectorDetailPageProps = {
+  params: Promise<{ slug: string }>;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+};
+
+const SECTOR_TABS = [
+  { value: "visao-geral", label: "Visao Geral" },
+  { value: "empresas", label: "Empresas" },
+] as const;
+
+export const dynamic = "force-dynamic";
+
+function SectorDetailError({
+  message,
+}: {
+  message: string;
+}) {
+  return (
+    <PageShell density="relaxed" className="max-w-4xl">
+      <SurfaceCard tone="hero" padding="hero" className="space-y-6">
+        <SectionHeading
+          eyebrow="PG-06 - Detalhe do setor"
+          title="Leitura setorial indisponivel"
+          titleAs="h1"
+          description="O detalhe do setor nao conseguiu concluir a leitura agora."
+        />
+        <Alert className="rounded-[1.75rem] border border-destructive/25 bg-destructive/6 px-5 py-5 text-left">
+          <AlertTitle>Falha controlada do detalhe setorial</AlertTitle>
+          <AlertDescription>{message}</AlertDescription>
+        </Alert>
+        <div className="flex flex-wrap gap-3">
+          <Link
+            href="/setores"
+            className={cn(buttonVariants({ size: "lg" }), "rounded-full px-5")}
+          >
+            Voltar para setores
+          </Link>
+          <Link
+            href="/empresas"
+            className={cn(
+              buttonVariants({ variant: "outline", size: "lg" }),
+              "rounded-full px-5",
+            )}
+          >
+            Abrir empresas
+          </Link>
+        </div>
+      </SurfaceCard>
+    </PageShell>
+  );
+}
+
+export async function generateMetadata({
+  params,
+}: SectorDetailPageProps): Promise<Metadata> {
+  const { slug } = await params;
+
+  try {
+    const detail = await fetchSectorDetail(slug);
+
+    if (!detail) {
+      return {
+        title: "Setor nao encontrado",
+      };
+    }
+
+    return {
+      title: detail.sector_name,
+      description: `Leitura setorial de ${detail.sector_name} com serie anual agregada e ranking anual de empresas.`,
+    };
+  } catch {
+    return {
+      title: "Leitura setorial indisponivel",
+    };
+  }
+}
+
+export default async function SectorDetailPage({
+  params,
+  searchParams,
+}: SectorDetailPageProps) {
+  const { slug } = await params;
+  const resolvedSearchParams = await searchParams;
+  const rawYear = getFirstParam(resolvedSearchParams.ano);
+  const rawTab = getFirstParam(resolvedSearchParams.aba);
+  const pathname = `/setores/${slug}`;
+
+  const { detail, currentTab, detailError } = await loadSectorDetailPageData(
+    slug,
+    rawYear,
+    rawTab,
+  );
+
+  if (!detail) {
+    if (!detailError) {
+      notFound();
+    }
+
+    return <SectorDetailError message={detailError} />;
+  }
+
+  return (
+    <PageShell density="default">
+      <SectorDetailTracker
+        sectorSlug={detail.sector_slug}
+        sectorName={detail.sector_name}
+        selectedYear={detail.selected_year}
+        companyCount={detail.company_count}
+      />
+
+      <div className="space-y-5">
+        <nav aria-label="breadcrumb">
+          <ol className="flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
+            <li>
+              <Link href="/" className="hover:text-foreground">
+                Home
+              </Link>
+            </li>
+            <li className="flex items-center gap-2">
+              <ChevronRightIcon className="size-4" />
+              <Link href="/setores" className="hover:text-foreground">
+                Setores
+              </Link>
+            </li>
+            <li className="flex items-center gap-2 text-foreground">
+              <ChevronRightIcon className="size-4 text-muted-foreground" />
+              <span>{detail.sector_name}</span>
+            </li>
+          </ol>
+        </nav>
+
+        <SurfaceCard tone="default" padding="lg">
+          <div className="flex flex-col gap-5 lg:flex-row lg:items-start lg:justify-between">
+            <div className="space-y-4">
+              <div className="flex flex-wrap items-center gap-3">
+                <InfoChip tone="brand">PG-06 - Detalhe do setor</InfoChip>
+                <InfoChip>{formatCompactInteger(detail.company_count)} empresas</InfoChip>
+                <InfoChip tone="muted">Base {detail.selected_year}</InfoChip>
+              </div>
+
+              <div className="space-y-3">
+                <h1 className="font-heading text-4xl tracking-[-0.05em] text-foreground sm:text-5xl">
+                  {detail.sector_name}
+                </h1>
+                <p className="max-w-3xl text-sm leading-7 text-muted-foreground">
+                  O detalhe setorial combina leitura agregada por ano e ranking
+                  anual de empresas, sempre sobre o mesmo slug canonico da API V2.
+                </p>
+              </div>
+            </div>
+
+            <div className="flex flex-wrap gap-3">
+              <Link
+                href={`/empresas?setor=${detail.sector_slug}`}
+                className={cn(
+                  buttonVariants({ variant: "outline", size: "lg" }),
+                  "rounded-full px-5",
+                )}
+              >
+                Filtrar empresas deste setor
+              </Link>
+            </div>
+          </div>
+        </SurfaceCard>
+      </div>
+
+      <SurfaceCard tone="subtle" padding="md" className="space-y-4">
+        <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+          <div className="space-y-2">
+            <p className="text-xs uppercase tracking-[0.26em] text-muted-foreground">
+              Recorte anual
+            </p>
+            <p className="text-sm leading-7 text-muted-foreground">
+              Ano invalido ou ausente cai automaticamente para o periodo mais
+              recente disponivel do setor.
+            </p>
+          </div>
+          <SectorYearSelector
+            pathname={pathname}
+            sectorSlug={detail.sector_slug}
+            availableYears={detail.available_years}
+            selectedYear={detail.selected_year}
+          />
+        </div>
+      </SurfaceCard>
+
+      <SectorUrlTabs
+        pathname={pathname}
+        currentValue={currentTab}
+        options={Array.from(SECTOR_TABS)}
+      />
+
+      {currentTab === "visao-geral" ? (
+        <SectorOverview detail={detail} />
+      ) : (
+        <SectorCompanyTable
+          companies={detail.companies}
+          sectorSlug={detail.sector_slug}
+          selectedYear={detail.selected_year}
+        />
+      )}
+    </PageShell>
+  );
+}

--- a/apps/web/app/setores/page.tsx
+++ b/apps/web/app/setores/page.tsx
@@ -1,0 +1,105 @@
+import Link from "next/link";
+import type { Metadata } from "next";
+
+import { SectorDirectoryList } from "@/components/sectors/sector-directory-list";
+import { SectorHubTracker } from "@/components/sectors/sector-hub-tracker";
+import {
+  InfoChip,
+  PageShell,
+  SectionHeading,
+  SurfaceCard,
+} from "@/components/shared/design-system-recipes";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { buttonVariants } from "@/components/ui/button";
+import { formatCompactInteger } from "@/lib/formatters";
+import { loadSectorsPageData } from "@/lib/sectors-page-data";
+import { cn } from "@/lib/utils";
+
+export const metadata: Metadata = {
+  title: "Setores",
+  description:
+    "Hub setorial da V2 web com leitura agregada por setor, contagem de empresas e snapshots anuais.",
+};
+
+export const dynamic = "force-dynamic";
+
+export default async function SetoresPage() {
+  const { directory, directoryError } = await loadSectorsPageData();
+
+  if (!directory) {
+    return (
+      <PageShell density="relaxed" className="max-w-4xl">
+        <SurfaceCard tone="hero" padding="hero" className="space-y-6">
+          <SectionHeading
+            eyebrow="PG-05 - Hub de setores"
+            title="Leitura setorial temporariamente indisponivel"
+            titleAs="h1"
+            description="O hub de setores nao respondeu agora. O restante da navegacao publica continua disponivel."
+          />
+          <Alert className="rounded-[1.75rem] border border-destructive/25 bg-destructive/6 px-5 py-5 text-left">
+            <AlertTitle>Falha controlada do hub setorial</AlertTitle>
+            <AlertDescription>
+              {directoryError ??
+                "Nao foi possivel carregar os setores agora. Tente novamente em instantes."}
+            </AlertDescription>
+          </Alert>
+          <div className="flex flex-wrap gap-3">
+            <Link
+              href="/setores"
+              className={cn(buttonVariants({ size: "lg" }), "rounded-full px-5")}
+            >
+              Tentar novamente
+            </Link>
+            <Link
+              href="/"
+              className={cn(
+                buttonVariants({ variant: "outline", size: "lg" }),
+                "rounded-full px-5",
+              )}
+            >
+              Voltar para a home
+            </Link>
+          </div>
+        </SurfaceCard>
+      </PageShell>
+    );
+  }
+
+  const totalCompanies = directory.items.reduce(
+    (accumulator, item) => accumulator + item.company_count,
+    0,
+  );
+
+  return (
+    <PageShell density="default">
+      <SectorHubTracker sectorCount={directory.items.length} />
+
+      <SectionHeading
+        eyebrow="PG-05 - Hub de setores"
+        title="Leitura por setores"
+        titleAs="h1"
+        description="Entre por cadeias produtivas e clusters analiticos para sair da navegacao empresa a empresa quando o problema e tematico."
+        meta={
+          <div className="flex flex-wrap items-center gap-2">
+            <InfoChip tone="muted">
+              {formatCompactInteger(directory.items.length)} setores
+            </InfoChip>
+            <InfoChip tone="muted">
+              {formatCompactInteger(totalCompanies)} empresas somadas
+            </InfoChip>
+          </div>
+        }
+      />
+
+      <SurfaceCard tone="subtle" padding="lg" className="space-y-4">
+        <p className="text-sm leading-7 text-muted-foreground">
+          Cada card entrega um snapshot do ano mais recente disponivel no setor,
+          mantendo metricas ausentes como lacunas explicitas em vez de
+          preenchimento artificial.
+        </p>
+      </SurfaceCard>
+
+      <SectorDirectoryList items={directory.items} />
+    </PageShell>
+  );
+}

--- a/apps/web/components/company/company-header.tsx
+++ b/apps/web/components/company/company-header.tsx
@@ -26,6 +26,13 @@ export function CompanyHeader({
     compareParams.set("anos", selectedYears.join(","));
   }
   const compareHref = `/comparar?${compareParams.toString()}`;
+  const latestSelectedYear = selectedYears[selectedYears.length - 1] ?? null;
+  const sectorHref =
+    company.sector_slug && latestSelectedYear
+      ? `/setores/${company.sector_slug}?ano=${latestSelectedYear}`
+      : company.sector_slug
+        ? `/setores/${company.sector_slug}`
+        : null;
 
   return (
     <div className="space-y-5">
@@ -83,14 +90,26 @@ export function CompanyHeader({
               }}
               className="rounded-full px-5"
             />
-            <Button
-              variant="outline"
-              size="lg"
-              className="rounded-full px-5"
-              disabled
-            >
-              Ver setor em breve
-            </Button>
+            {sectorHref ? (
+              <Link
+                href={sectorHref}
+                className={cn(
+                  buttonVariants({ variant: "outline", size: "lg" }),
+                  "rounded-full px-5",
+                )}
+              >
+                Ver setor
+              </Link>
+            ) : (
+              <Button
+                variant="outline"
+                size="lg"
+                className="rounded-full px-5"
+                disabled
+              >
+                Setor indisponivel
+              </Button>
+            )}
             <Link
               href={compareHref}
               className={cn(

--- a/apps/web/components/sectors/sector-company-link.tsx
+++ b/apps/web/components/sectors/sector-company-link.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import Link from "next/link";
+import type { ReactNode } from "react";
+
+import { track } from "@/lib/track";
+
+type SectorCompanyLinkProps = {
+  href: string;
+  sectorSlug: string;
+  selectedYear: number;
+  cdCvm: number;
+  companyName: string;
+  children: ReactNode;
+  className?: string;
+};
+
+export function SectorCompanyLink({
+  href,
+  sectorSlug,
+  selectedYear,
+  cdCvm,
+  companyName,
+  children,
+  className,
+}: SectorCompanyLinkProps) {
+  return (
+    <Link
+      href={href}
+      className={className}
+      onClick={() => {
+        track("sector_company_clicked", {
+          sector_slug: sectorSlug,
+          selected_year: selectedYear,
+          cd_cvm: cdCvm,
+          company_name: companyName,
+        });
+      }}
+    >
+      {children}
+    </Link>
+  );
+}

--- a/apps/web/components/sectors/sector-company-table.tsx
+++ b/apps/web/components/sectors/sector-company-table.tsx
@@ -1,0 +1,99 @@
+import {
+  SectionHeading,
+  SurfaceCard,
+} from "@/components/shared/design-system-recipes";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import type { SectorCompanyMetric } from "@/lib/api";
+import { formatKpiValue } from "@/lib/formatters";
+import { cn } from "@/lib/utils";
+
+import { SectorCompanyLink } from "./sector-company-link";
+
+type SectorCompanyTableProps = {
+  companies: SectorCompanyMetric[];
+  sectorSlug: string;
+  selectedYear: number;
+};
+
+export function SectorCompanyTable({
+  companies,
+  sectorSlug,
+  selectedYear,
+}: SectorCompanyTableProps) {
+  if (companies.length === 0) {
+    return (
+      <SurfaceCard tone="muted" padding="hero" className="space-y-5">
+        <SectionHeading
+          eyebrow="Empresas do setor"
+          title="Nenhuma empresa comparavel neste ano"
+          titleAs="h2"
+          description="O setor existe, mas o recorte anual ativo nao retornou empresas listaveis com este contrato."
+          descriptionClassName="text-sm leading-7"
+        />
+      </SurfaceCard>
+    );
+  }
+
+  return (
+    <section className="space-y-4">
+      <SectionHeading
+        eyebrow="Empresas do setor"
+        title="Ranking anual por companhia"
+        titleAs="h2"
+        description="A ordenacao principal usa ROE decrescente e preserva empresas com metricas faltantes no fim da lista."
+        descriptionClassName="text-sm leading-7"
+      />
+
+      <SurfaceCard tone="default" padding="none" className="overflow-hidden">
+        <Table>
+          <TableHeader className="bg-muted/35">
+            <TableRow>
+              <TableHead className="px-5">Rank</TableHead>
+              <TableHead>Empresa</TableHead>
+              <TableHead>Ticker</TableHead>
+              <TableHead>ROE</TableHead>
+              <TableHead>Margem EBIT</TableHead>
+              <TableHead>Margem Liquida</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {companies.map((company, index) => (
+              <TableRow key={company.cd_cvm} data-testid="sector-company-row">
+                <TableCell className="px-5 text-muted-foreground">
+                  {index + 1}
+                </TableCell>
+                <TableCell className="max-w-[20rem]">
+                  <SectorCompanyLink
+                    href={`/empresas/${company.cd_cvm}?anos=${selectedYear}`}
+                    sectorSlug={sectorSlug}
+                    selectedYear={selectedYear}
+                    cdCvm={company.cd_cvm}
+                    companyName={company.company_name}
+                    className={cn(
+                      "font-medium text-foreground transition-colors hover:text-primary",
+                    )}
+                  >
+                    {company.company_name}
+                  </SectorCompanyLink>
+                </TableCell>
+                <TableCell className="text-muted-foreground">
+                  {company.ticker_b3 ?? "-"}
+                </TableCell>
+                <TableCell>{formatKpiValue(company.roe, "pct")}</TableCell>
+                <TableCell>{formatKpiValue(company.mg_ebit, "pct")}</TableCell>
+                <TableCell>{formatKpiValue(company.mg_liq, "pct")}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </SurfaceCard>
+    </section>
+  );
+}

--- a/apps/web/components/sectors/sector-detail-tracker.tsx
+++ b/apps/web/components/sectors/sector-detail-tracker.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { useEffect } from "react";
+
+import { track } from "@/lib/track";
+
+type SectorDetailTrackerProps = {
+  sectorSlug: string;
+  sectorName: string;
+  selectedYear: number;
+  companyCount: number;
+};
+
+export function SectorDetailTracker({
+  sectorSlug,
+  sectorName,
+  selectedYear,
+  companyCount,
+}: SectorDetailTrackerProps) {
+  useEffect(() => {
+    track("sector_detail_viewed", {
+      sector_slug: sectorSlug,
+      sector_name: sectorName,
+      selected_year: selectedYear,
+      company_count: companyCount,
+    });
+  }, [companyCount, sectorName, sectorSlug, selectedYear]);
+
+  return null;
+}

--- a/apps/web/components/sectors/sector-directory-list.tsx
+++ b/apps/web/components/sectors/sector-directory-list.tsx
@@ -1,0 +1,109 @@
+import Link from "next/link";
+import { ArrowUpRightIcon, Building2Icon } from "lucide-react";
+
+import {
+  InfoChip,
+  SurfaceCard,
+} from "@/components/shared/design-system-recipes";
+import { buttonVariants } from "@/components/ui/button";
+import type { SectorDirectoryItem } from "@/lib/api";
+import { formatCompactInteger, formatKpiValue } from "@/lib/formatters";
+import { cn } from "@/lib/utils";
+
+type SectorDirectoryListProps = {
+  items: SectorDirectoryItem[];
+};
+
+const SNAPSHOT_METRICS = [
+  { key: "roe", label: "ROE" },
+  { key: "mg_ebit", label: "Margem EBIT" },
+  { key: "mg_liq", label: "Margem Liquida" },
+] as const;
+
+export function SectorDirectoryList({ items }: SectorDirectoryListProps) {
+  if (items.length === 0) {
+    return (
+      <SurfaceCard
+        tone="muted"
+        padding="hero"
+        className="items-center text-center"
+      >
+        <p className="font-heading text-2xl text-foreground">
+          Nenhum setor disponivel.
+        </p>
+        <p className="max-w-2xl text-sm leading-7 text-muted-foreground">
+          A API nao retornou setores prontos para leitura agora. Tente novamente
+          em instantes.
+        </p>
+      </SurfaceCard>
+    );
+  }
+
+  return (
+    <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+      {items.map((item) => (
+        <SurfaceCard
+          key={item.sector_slug}
+          tone="default"
+          padding="lg"
+          className="flex h-full flex-col justify-between gap-6"
+        >
+          <div className="space-y-5">
+            <div className="flex items-start justify-between gap-4">
+              <div className="space-y-3">
+                <div className="flex flex-wrap items-center gap-3">
+                  <h2 className="font-heading text-2xl leading-tight text-foreground">
+                    {item.sector_name}
+                  </h2>
+                  <InfoChip tone="muted">
+                    {formatCompactInteger(item.company_count)} empresas
+                  </InfoChip>
+                </div>
+                <p className="text-sm leading-7 text-muted-foreground">
+                  Snapshot agregado do ano mais recente disponivel para o setor.
+                </p>
+              </div>
+
+              <div className="flex size-11 shrink-0 items-center justify-center rounded-full border border-border/70 bg-muted/45 text-muted-foreground">
+                <Building2Icon className="size-5" />
+              </div>
+            </div>
+
+            <div className="grid gap-3">
+              {SNAPSHOT_METRICS.map((metric) => (
+                <div
+                  key={metric.key}
+                  className="flex items-center justify-between gap-3 rounded-[1.2rem] border border-border/55 bg-muted/35 px-4 py-3"
+                >
+                  <span className="text-sm text-muted-foreground">
+                    {metric.label}
+                  </span>
+                  <span className="font-medium text-foreground">
+                    {formatKpiValue(item.snapshot[metric.key], "pct")}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div className="flex items-center justify-between gap-3 border-t border-border/55 pt-5">
+            <p className="text-xs uppercase tracking-[0.22em] text-muted-foreground">
+              Base {item.latest_year ?? "-"}
+            </p>
+            <Link
+              href={`/setores/${item.sector_slug}`}
+              data-testid="sector-card-link"
+              className={cn(
+                buttonVariants({ variant: "outline", size: "lg" }),
+                "rounded-full px-5",
+              )}
+            >
+              Abrir setor
+              <ArrowUpRightIcon className="size-4" />
+            </Link>
+          </div>
+        </SurfaceCard>
+      ))}
+    </section>
+  );
+}

--- a/apps/web/components/sectors/sector-hub-tracker.tsx
+++ b/apps/web/components/sectors/sector-hub-tracker.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { useEffect } from "react";
+
+import { track } from "@/lib/track";
+
+type SectorHubTrackerProps = {
+  sectorCount: number;
+};
+
+export function SectorHubTracker({ sectorCount }: SectorHubTrackerProps) {
+  useEffect(() => {
+    track("sectors_hub_viewed", {
+      sector_count: sectorCount,
+    });
+  }, [sectorCount]);
+
+  return null;
+}

--- a/apps/web/components/sectors/sector-overview.tsx
+++ b/apps/web/components/sectors/sector-overview.tsx
@@ -1,0 +1,102 @@
+import { Badge } from "@/components/ui/badge";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  SectionHeading,
+  SurfaceCard,
+} from "@/components/shared/design-system-recipes";
+import type { SectorDetail } from "@/lib/api";
+import { formatKpiValue } from "@/lib/formatters";
+
+type SectorOverviewProps = {
+  detail: SectorDetail;
+};
+
+const OVERVIEW_METRICS = [
+  { key: "roe", label: "ROE" },
+  { key: "mg_ebit", label: "Margem EBIT" },
+  { key: "mg_liq", label: "Margem Liquida" },
+] as const;
+
+export function SectorOverview({ detail }: SectorOverviewProps) {
+  const selectedYearSnapshot =
+    detail.yearly_overview.find((entry) => entry.year === detail.selected_year) ??
+    detail.yearly_overview[detail.yearly_overview.length - 1] ??
+    null;
+
+  return (
+    <div className="space-y-8">
+      <section className="space-y-5">
+        <SectionHeading
+          eyebrow="Visao geral setorial"
+          title="KPIs agregados do recorte selecionado"
+          titleAs="h2"
+          description="Os valores abaixo refletem a leitura agregada do setor no ano ativo, mantendo lacunas como `null` em vez de inventar preenchimento."
+          descriptionClassName="text-sm leading-7"
+        />
+
+        <div className="grid gap-4 md:grid-cols-3">
+          {OVERVIEW_METRICS.map((metric) => (
+            <SurfaceCard key={metric.key} tone="subtle" padding="md">
+              <div className="space-y-4">
+                <div className="flex items-center justify-between gap-3">
+                  <p className="text-sm text-muted-foreground">{metric.label}</p>
+                  <Badge
+                    variant="outline"
+                    className="rounded-full border-border/75 bg-background/70 text-[0.68rem] uppercase tracking-[0.16em] text-muted-foreground"
+                  >
+                    {detail.selected_year}
+                  </Badge>
+                </div>
+                <p className="font-heading text-3xl tracking-[-0.04em] text-foreground">
+                  {formatKpiValue(selectedYearSnapshot?.[metric.key] ?? null, "pct")}
+                </p>
+              </div>
+            </SurfaceCard>
+          ))}
+        </div>
+      </section>
+
+      <section className="space-y-4">
+        <SectionHeading
+          eyebrow="Serie anual"
+          title="Leitura curta por ano"
+          titleAs="h3"
+          description="A serie abaixo ajuda a comparar o ano ativo com o historico recente do mesmo setor."
+          descriptionClassName="text-sm leading-7"
+        />
+
+        <SurfaceCard tone="default" padding="none" className="overflow-hidden">
+          <Table>
+            <TableHeader className="bg-muted/35">
+              <TableRow>
+                <TableHead className="px-5">Ano</TableHead>
+                <TableHead>ROE</TableHead>
+                <TableHead>Margem EBIT</TableHead>
+                <TableHead>Margem Liquida</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {detail.yearly_overview.map((entry) => (
+                <TableRow key={entry.year}>
+                  <TableCell className="px-5 font-medium text-foreground">
+                    {entry.year}
+                  </TableCell>
+                  <TableCell>{formatKpiValue(entry.roe, "pct")}</TableCell>
+                  <TableCell>{formatKpiValue(entry.mg_ebit, "pct")}</TableCell>
+                  <TableCell>{formatKpiValue(entry.mg_liq, "pct")}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </SurfaceCard>
+      </section>
+    </div>
+  );
+}

--- a/apps/web/components/sectors/sector-url-tabs.tsx
+++ b/apps/web/components/sectors/sector-url-tabs.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { startTransition } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { mergeSearchParams } from "@/lib/search-params";
+
+type SectorUrlTabsProps = {
+  pathname: string;
+  currentValue: string;
+  options: Array<{ value: string; label: string }>;
+};
+
+export function SectorUrlTabs({
+  pathname,
+  currentValue,
+  options,
+}: SectorUrlTabsProps) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  return (
+    <Tabs
+      value={currentValue}
+      onValueChange={(value) => {
+        const query = mergeSearchParams(searchParams.toString(), {
+          aba: value,
+        });
+
+        startTransition(() => {
+          router.push(`${pathname}?${query}`);
+        });
+      }}
+    >
+      <TabsList
+        variant="underline"
+        className="w-fit rounded-full border border-border/70 bg-background/88 p-1"
+      >
+        {options.map((option) => (
+          <TabsTrigger
+            key={option.value}
+            value={option.value}
+            className="rounded-full px-4 py-2 text-sm data-[active]:bg-muted/75 data-[active]:shadow-sm"
+          >
+            {option.label}
+          </TabsTrigger>
+        ))}
+      </TabsList>
+    </Tabs>
+  );
+}

--- a/apps/web/components/sectors/sector-year-selector.tsx
+++ b/apps/web/components/sectors/sector-year-selector.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { startTransition } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+
+import { Button } from "@/components/ui/button";
+import { mergeSearchParams } from "@/lib/search-params";
+import { track } from "@/lib/track";
+
+type SectorYearSelectorProps = {
+  pathname: string;
+  sectorSlug: string;
+  availableYears: number[];
+  selectedYear: number;
+};
+
+export function SectorYearSelector({
+  pathname,
+  sectorSlug,
+  availableYears,
+  selectedYear,
+}: SectorYearSelectorProps) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const yearOptions = [...availableYears].sort((left, right) => right - left);
+
+  function selectYear(year: number) {
+    const query = mergeSearchParams(searchParams.toString(), {
+      ano: year,
+    });
+
+    track("sector_year_changed", {
+      sector_slug: sectorSlug,
+      year,
+    });
+
+    startTransition(() => {
+      router.push(`${pathname}?${query}`);
+    });
+  }
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      {yearOptions.map((year) => {
+        const active = year === selectedYear;
+
+        return (
+          <Button
+            key={year}
+            type="button"
+            variant={active ? "secondary" : "outline"}
+            size="sm"
+            className="rounded-full px-4"
+            onClick={() => selectYear(year)}
+          >
+            {year}
+          </Button>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/components/shared/site-footer.tsx
+++ b/apps/web/components/shared/site-footer.tsx
@@ -7,7 +7,7 @@ const SITEMAP = [
       { label: "Home", href: "/" },
       { label: "Empresas", href: "/empresas" },
       { label: "Comparar", href: "/comparar" },
-      { label: "Setores", href: null },
+      { label: "Setores", href: "/setores" },
     ],
   },
   {
@@ -47,7 +47,8 @@ export function SiteFooter() {
             </p>
             <p className="mt-2 text-sm leading-7 text-muted-foreground">
               V2 web como camada read-only sobre a API estabilizada. Fluxos de
-              refresh e dominios setoriais entram nas proximas fases.
+              comparacao e leitura setorial ja estao ativos, com KPIs e macro
+              entrando nas proximas fases.
             </p>
           </div>
 

--- a/apps/web/components/shared/site-header.tsx
+++ b/apps/web/components/shared/site-header.tsx
@@ -7,7 +7,7 @@ const PRIMARY_NAV = [
   { label: "Home", href: "/" },
   { label: "Empresas", href: "/empresas" },
   { label: "Comparar", href: "/comparar" },
-  { label: "Setores", href: null },
+  { label: "Setores", href: "/setores" },
   { label: "KPIs", href: null },
   { label: "Macro", href: null },
 ] as const;

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -80,6 +80,50 @@ export type StatementMatrix = {
   exclude_conflicts: boolean;
 };
 
+export type SectorSnapshot = {
+  roe: number | null;
+  mg_ebit: number | null;
+  mg_liq: number | null;
+};
+
+export type SectorDirectoryItem = {
+  sector_name: string;
+  sector_slug: string;
+  company_count: number;
+  latest_year: number | null;
+  snapshot: SectorSnapshot;
+};
+
+export type SectorDirectory = {
+  items: SectorDirectoryItem[];
+};
+
+export type SectorYearOverview = {
+  year: number;
+  roe: number | null;
+  mg_ebit: number | null;
+  mg_liq: number | null;
+};
+
+export type SectorCompanyMetric = {
+  cd_cvm: number;
+  company_name: string;
+  ticker_b3: string | null;
+  roe: number | null;
+  mg_ebit: number | null;
+  mg_liq: number | null;
+};
+
+export type SectorDetail = {
+  sector_name: string;
+  sector_slug: string;
+  company_count: number;
+  available_years: number[];
+  selected_year: number;
+  yearly_overview: SectorYearOverview[];
+  companies: SectorCompanyMetric[];
+};
+
 type ApiErrorShape = {
   error?: {
     code?: string;
@@ -210,6 +254,66 @@ function isStatementMatrix(value: unknown): value is StatementMatrix {
     isNumberArray(value.years) &&
     isTabularData(value.table) &&
     typeof value.exclude_conflicts === "boolean"
+  );
+}
+
+function isNullableNumber(value: unknown): value is number | null {
+  return value === null || typeof value === "number";
+}
+
+function isSectorSnapshot(value: unknown): value is SectorSnapshot {
+  return (
+    isRecord(value) &&
+    isNullableNumber(value.roe) &&
+    isNullableNumber(value.mg_ebit) &&
+    isNullableNumber(value.mg_liq)
+  );
+}
+
+function isSectorDirectory(value: unknown): value is SectorDirectory {
+  return (
+    isRecord(value) &&
+    Array.isArray(value.items) &&
+    value.items.every(
+      (item) =>
+        isRecord(item) &&
+        typeof item.sector_name === "string" &&
+        typeof item.sector_slug === "string" &&
+        typeof item.company_count === "number" &&
+        isNullableNumber(item.latest_year) &&
+        isSectorSnapshot(item.snapshot),
+    )
+  );
+}
+
+function isSectorDetail(value: unknown): value is SectorDetail {
+  return (
+    isRecord(value) &&
+    typeof value.sector_name === "string" &&
+    typeof value.sector_slug === "string" &&
+    typeof value.company_count === "number" &&
+    isNumberArray(value.available_years) &&
+    typeof value.selected_year === "number" &&
+    Array.isArray(value.yearly_overview) &&
+    value.yearly_overview.every(
+      (entry) =>
+        isRecord(entry) &&
+        typeof entry.year === "number" &&
+        isNullableNumber(entry.roe) &&
+        isNullableNumber(entry.mg_ebit) &&
+        isNullableNumber(entry.mg_liq),
+    ) &&
+    Array.isArray(value.companies) &&
+    value.companies.every(
+      (company) =>
+        isRecord(company) &&
+        typeof company.cd_cvm === "number" &&
+        typeof company.company_name === "string" &&
+        (company.ticker_b3 === null || typeof company.ticker_b3 === "string") &&
+        isNullableNumber(company.roe) &&
+        isNullableNumber(company.mg_ebit) &&
+        isNullableNumber(company.mg_liq),
+    )
   );
 }
 
@@ -443,6 +547,27 @@ export async function fetchCompanyFilters(): Promise<CompanyFiltersResponse> {
       invalidResponseMessage: "A API retornou filtros de empresas invalidos.",
     },
   )) as CompanyFiltersResponse;
+}
+
+export async function fetchSectorDirectory(): Promise<SectorDirectory> {
+  return (await apiFetch<SectorDirectory>("/sectors", {
+    validate: isSectorDirectory,
+    invalidResponseMessage: "A API retornou um diretorio de setores invalido.",
+  })) as SectorDirectory;
+}
+
+export async function fetchSectorDetail(
+  sectorSlug: string,
+  year?: number,
+): Promise<SectorDetail | null> {
+  return apiFetch<SectorDetail>(
+    `/sectors/${sectorSlug}${buildQuery({ year })}`,
+    {
+      allowNotFound: true,
+      validate: isSectorDetail,
+      invalidResponseMessage: "A API retornou um detalhe setorial invalido.",
+    },
+  );
 }
 
 export async function fetchCompanyInfo(

--- a/apps/web/lib/constants.ts
+++ b/apps/web/lib/constants.ts
@@ -8,8 +8,8 @@ export const HOME_QUICK_LINKS = [
   {
     label: "Setores",
     description: "Leitura tematica por clusters e cadeias produtivas.",
-    href: null,
-    status: "em-breve",
+    href: "/setores",
+    status: "disponivel",
   },
   {
     label: "KPIs",

--- a/apps/web/lib/sectors-page-data.ts
+++ b/apps/web/lib/sectors-page-data.ts
@@ -1,0 +1,120 @@
+import {
+  fetchSectorDetail,
+  fetchSectorDirectory,
+  getUserFacingErrorMessage,
+  type SectorDetail,
+  type SectorDirectory,
+} from "./api.ts";
+
+export type SectorPageTab = "visao-geral" | "empresas";
+
+type SectorLoaders = {
+  fetchDirectory?: () => Promise<SectorDirectory>;
+  fetchDetail?: (slug: string, year?: number) => Promise<SectorDetail | null>;
+};
+
+export type SectorsPageData = {
+  directory: SectorDirectory | null;
+  directoryError: string | null;
+};
+
+export type SectorDetailPageData = {
+  detail: SectorDetail | null;
+  currentTab: SectorPageTab;
+  detailError: string | null;
+};
+
+export function coerceSectorTab(value: string | undefined): SectorPageTab {
+  return value === "empresas" ? "empresas" : "visao-geral";
+}
+
+export function resolveSectorYear(
+  availableYears: number[],
+  rawYear: string | undefined,
+  fallbackYear: number,
+): number {
+  if (!rawYear) {
+    return fallbackYear;
+  }
+
+  const parsed = Number.parseInt(rawYear, 10);
+  if (!Number.isFinite(parsed) || !availableYears.includes(parsed)) {
+    return fallbackYear;
+  }
+
+  return parsed;
+}
+
+export async function loadSectorsPageData(
+  loaders: SectorLoaders = {},
+): Promise<SectorsPageData> {
+  const fetchDirectory = loaders.fetchDirectory ?? fetchSectorDirectory;
+
+  try {
+    return {
+      directory: await fetchDirectory(),
+      directoryError: null,
+    };
+  } catch (error) {
+    return {
+      directory: null,
+      directoryError: getUserFacingErrorMessage(error),
+    };
+  }
+}
+
+export async function loadSectorDetailPageData(
+  sectorSlug: string,
+  rawYear: string | undefined,
+  rawTab: string | undefined,
+  loaders: SectorLoaders = {},
+): Promise<SectorDetailPageData> {
+  const fetchDetail = loaders.fetchDetail ?? fetchSectorDetail;
+  const currentTab = coerceSectorTab(rawTab);
+
+  try {
+    const latestDetail = await fetchDetail(sectorSlug);
+
+    if (!latestDetail) {
+      return {
+        detail: null,
+        currentTab,
+        detailError: null,
+      };
+    }
+
+    const resolvedYear = resolveSectorYear(
+      latestDetail.available_years,
+      rawYear,
+      latestDetail.selected_year,
+    );
+
+    if (resolvedYear === latestDetail.selected_year) {
+      return {
+        detail: latestDetail,
+        currentTab,
+        detailError: null,
+      };
+    }
+
+    let yearScopedDetail: SectorDetail | null = null;
+
+    try {
+      yearScopedDetail = await fetchDetail(sectorSlug, resolvedYear);
+    } catch {
+      yearScopedDetail = null;
+    }
+
+    return {
+      detail: yearScopedDetail ?? latestDetail,
+      currentTab,
+      detailError: null,
+    };
+  } catch (error) {
+    return {
+      detail: null,
+      currentTab,
+      detailError: getUserFacingErrorMessage(error),
+    };
+  }
+}

--- a/apps/web/lib/track.ts
+++ b/apps/web/lib/track.ts
@@ -15,7 +15,11 @@ export type TrackEventName =
   | "compare_company_removed"
   | "compare_years_changed"
   | "compare_adjust_clicked"
-  | "compare_reset_clicked";
+  | "compare_reset_clicked"
+  | "sectors_hub_viewed"
+  | "sector_detail_viewed"
+  | "sector_year_changed"
+  | "sector_company_clicked";
 
 type TrackPayload = Record<string, string | number | boolean | null | undefined>;
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -8,7 +8,7 @@
     "start": "next start",
     "lint": "eslint",
     "typecheck": "tsc --noEmit",
-    "test:unit": "node --experimental-strip-types --experimental-specifier-resolution=node --test tests/api-client.test.ts tests/companies-page-data.test.ts tests/compare-utils.test.ts tests/compare-page-data.test.ts",
+    "test:unit": "node --experimental-strip-types --experimental-specifier-resolution=node --test tests/api-client.test.ts tests/companies-page-data.test.ts tests/compare-utils.test.ts tests/compare-page-data.test.ts tests/sectors-page-data.test.ts",
     "test:e2e": "playwright test"
   },
   "dependencies": {

--- a/apps/web/tests/sectors-page-data.test.ts
+++ b/apps/web/tests/sectors-page-data.test.ts
@@ -1,0 +1,121 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { ApiClientError } from "../lib/api.ts";
+import {
+  loadSectorDetailPageData,
+  loadSectorsPageData,
+} from "../lib/sectors-page-data.ts";
+
+const sampleDirectory = {
+  items: [
+    {
+      sector_name: "Energia",
+      sector_slug: "energia",
+      company_count: 12,
+      latest_year: 2024,
+      snapshot: {
+        roe: 0.18,
+        mg_ebit: 0.22,
+        mg_liq: 0.14,
+      },
+    },
+  ],
+};
+
+const latestSectorDetail = {
+  sector_name: "Energia",
+  sector_slug: "energia",
+  company_count: 12,
+  available_years: [2022, 2023, 2024],
+  selected_year: 2024,
+  yearly_overview: [
+    { year: 2022, roe: 0.12, mg_ebit: 0.18, mg_liq: 0.09 },
+    { year: 2023, roe: 0.16, mg_ebit: 0.2, mg_liq: 0.11 },
+    { year: 2024, roe: 0.18, mg_ebit: 0.22, mg_liq: 0.14 },
+  ],
+  companies: [
+    {
+      cd_cvm: 9512,
+      company_name: "PETROBRAS",
+      ticker_b3: "PETR4",
+      roe: 0.25,
+      mg_ebit: 0.28,
+      mg_liq: 0.17,
+    },
+  ],
+};
+
+const scopedSectorDetail = {
+  ...latestSectorDetail,
+  selected_year: 2023,
+  companies: [
+    {
+      cd_cvm: 9512,
+      company_name: "PETROBRAS",
+      ticker_b3: "PETR4",
+      roe: 0.21,
+      mg_ebit: 0.24,
+      mg_liq: 0.13,
+    },
+  ],
+};
+
+test("loadSectorsPageData returns a stable error when the directory fails", async () => {
+  const result = await loadSectorsPageData({
+    fetchDirectory: async () => {
+      throw new ApiClientError("Nao foi possivel conectar a API da V2.", 503, "network_error");
+    },
+  });
+
+  assert.equal(result.directory, null);
+  assert.match(result.directoryError ?? "", /Nao foi possivel conectar a API da V2/i);
+});
+
+test("loadSectorDetailPageData falls back to the latest year when ano is invalid", async () => {
+  const calls: Array<number | undefined> = [];
+
+  const result = await loadSectorDetailPageData("energia", "1900", "empresas", {
+    fetchDetail: async (_slug, year) => {
+      calls.push(year);
+      return latestSectorDetail;
+    },
+  });
+
+  assert.deepEqual(calls, [undefined]);
+  assert.equal(result.currentTab, "empresas");
+  assert.equal(result.detail?.selected_year, 2024);
+});
+
+test("loadSectorDetailPageData refetches when ano is valid and within the available range", async () => {
+  const calls: Array<number | undefined> = [];
+
+  const result = await loadSectorDetailPageData("energia", "2023", "visao-geral", {
+    fetchDetail: async (_slug, year) => {
+      calls.push(year);
+      return year === 2023 ? scopedSectorDetail : latestSectorDetail;
+    },
+  });
+
+  assert.deepEqual(calls, [undefined, 2023]);
+  assert.equal(result.currentTab, "visao-geral");
+  assert.equal(result.detail?.selected_year, 2023);
+});
+
+test("loadSectorDetailPageData keeps the latest detail when the scoped request fails", async () => {
+  const calls: Array<number | undefined> = [];
+
+  const result = await loadSectorDetailPageData("energia", "2023", undefined, {
+    fetchDetail: async (_slug, year) => {
+      calls.push(year);
+      if (year === 2023) {
+        throw new ApiClientError("A API da V2 esta indisponivel no momento.", 503, "upstream_unavailable");
+      }
+      return latestSectorDetail;
+    },
+  });
+
+  assert.deepEqual(calls, [undefined, 2023]);
+  assert.equal(result.detail?.selected_year, 2024);
+  assert.equal(result.detailError, null);
+});

--- a/apps/web/tests/sectors.spec.ts
+++ b/apps/web/tests/sectors.spec.ts
@@ -1,0 +1,63 @@
+import { expect, test } from "@playwright/test";
+
+test("hub de setores abre e navega para o detalhe", async ({ page }) => {
+  await page.goto("/setores");
+
+  await expect(
+    page.getByRole("heading", { name: /leitura por setores/i }),
+  ).toBeVisible({ timeout: 30_000 });
+
+  const firstSectorLink = page.getByTestId("sector-card-link").first();
+  await expect(firstSectorLink).toBeVisible({ timeout: 30_000 });
+
+  await firstSectorLink.click();
+
+  await expect(page).toHaveURL(/\/setores\/[^/?#]+/i, {
+    timeout: 30_000,
+  });
+  await expect(
+    page.getByRole("heading", { level: 1 }),
+  ).toBeVisible({ timeout: 30_000 });
+});
+
+test("ano invalido cai para o ano mais recente disponivel do setor", async ({ page }) => {
+  await page.goto("/setores");
+
+  const firstBaseLabel = page.locator("text=/Base\\s+\\d{4}/").first();
+  const baseText = (await firstBaseLabel.textContent()) ?? "";
+  const latestYearMatch = baseText.match(/(\d{4})/);
+  expect(latestYearMatch).not.toBeNull();
+
+  const href = await page.getByTestId("sector-card-link").first().getAttribute("href");
+  expect(href).toBeTruthy();
+
+  await page.goto(`${href}?ano=1900`);
+
+  await expect(
+    page.getByText(new RegExp(`Base\\s+${latestYearMatch?.[1]}`, "i")),
+  ).toBeVisible({ timeout: 30_000 });
+});
+
+test("detalhe da empresa aponta para o detalhe do setor com o ano mais recente", async ({ page }) => {
+  await page.goto("/empresas/9512?anos=2023,2024");
+
+  await expect(page.locator("h1").first()).toContainText(/PETROBRAS/i, {
+    timeout: 30_000,
+  });
+
+  await page.getByRole("link", { name: /ver setor/i }).click();
+
+  await expect(page).toHaveURL(/\/setores\/[^/?#]+\?ano=2024/i, {
+    timeout: 30_000,
+  });
+});
+
+test("slug inexistente cai em not-found", async ({ page }) => {
+  await page.goto("/setores/slug-inexistente");
+
+  await expect(
+    page.getByRole("heading", {
+      name: /esse caminho ainda nao existe nesta fase/i,
+    }),
+  ).toBeVisible({ timeout: 30_000 });
+});


### PR DESCRIPTION
## Resumo
- publica `/setores` e `/setores/[slug]` como rotas live na V2 web
- consome a backend child task `#81` usando apenas `GET /sectors` e `GET /sectors/{slug}`
- promove `Setores` na navegacao principal, na home e no CTA da pagina da empresa
- adiciona tracking e cobertura de testes para hub, detalhe e deep-link anual

## Dependencias
- child task backend consumida: #81
- child task docs pendente de consumo antes do merge final: #82

## Validacao
- `cd apps/web && npm run typecheck`
- `cd apps/web && npm run test:unit`
- `cd apps/web && npm run build`
- `cd apps/web && $env:CI=''1''; $env:PLAYWRIGHT_WEB_PORT=''3100''; $env:PLAYWRIGHT_API_PORT=''8100''; npm run test:e2e`

Closes #80